### PR TITLE
:art: get rid of "non-serializable" warning

### DIFF
--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -34,7 +34,7 @@ export interface OGCCollection {
   itemType?: string;
   links?: Array<Link>;
   extent?: Spatial;
-  properties?: Map<string, any>;
+  properties?: { [key: string]: any };
 }
 
 export interface OGCCollections {
@@ -115,9 +115,6 @@ const searchResult = async (param: SearchParameters, thunkApi: any) => {
     const collections: OGCCollections = response.data;
     collections?.collections?.forEach((o, index) => {
       o.index = "" + (index + 1);
-      if (o.properties && typeof o.properties === "object") {
-        o.properties = new Map(Object.entries(o.properties));
-      }
     });
 
     return collections;

--- a/src/components/result/ResultCards.tsx
+++ b/src/components/result/ResultCards.tsx
@@ -123,7 +123,7 @@ const ResultCard = (props: ResultCardProps) => {
           }
         />
         <DynamicResultCardButton
-          status={props.content.properties.get("STATUS")}
+          status={props.content.properties?.STATUS}
           onClick={() => {}}
         />
         <StaticResultCardButton


### PR DESCRIPTION
Map() is not serializable so redux throw a warning for this field. Now I changed it into an index signature field and the warning has gone.