### PR TITLE
:bug: fix search bar category bug and enter event bug

### DIFF
--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -303,9 +303,12 @@ const createSearchParamFrom = (i: ParameterState): SearchParameters => {
     p.filter = appendFilter(p.filter, f(i.polygon));
   }
 
-  if (i.categories) {
+  if (i.categories && i.categories.length > 0) {
     const f = cqlDefaultFilters.get("CATEGORIES_IN") as CategoriesIn;
-    p.filter = appendFilter(p.filter, f(i.categories));
+    const categoryFilter = f(i.categories);
+    if (categoryFilter) {
+      p.filter = appendFilter(p.filter, categoryFilter);
+    }
   }
 
   return p;

--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -240,10 +240,13 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
   const handleKeyDown = (
     event: React.KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
-    if (event.key === "Enter") {
+    if (event.key === "Enter" && open === true) {
       setOpen(false);
+      handleEnterPressed(event, false);
     }
-    handleEnterPressed(event, open);
+    if (event.key === "Enter" && open === false) {
+      handleEnterPressed(event, false);
+    }
   };
 
   const [searchFieldWidth, setSearchFieldWidth] = useState<number>(0);


### PR DESCRIPTION
1. fix search bar filter category bug. This bug can be tested in search result page:
select some categories from filter -> remove them from search input bar -> resize the window to change map bbox to trigger fetching datasets automatically -> go to network see if query param string is correct or not

2. fix search bar enter event bug. This bug can be tested in landing page:
enter 'imos' in search input bar quickly and press enter -> can do search successfully and nav to search result page

