### PR TITLE
Bug/5704 duplicate other constraints

### DIFF
--- a/src/components/list/LicenseList.tsx
+++ b/src/components/list/LicenseList.tsx
@@ -43,7 +43,7 @@ const LicenseList: React.FC<LicenseListProps> = ({ license, url, graphic }) => {
                 </Link>
               </Grid>
               <Grid item md={12}>
-                <img src={graphic} alt="license graphic" />
+                {graphic && <img src={graphic} alt="license graphic" />}
               </Grid>
             </Grid>
           </Grid>

--- a/src/pages/detail-page/subpages/tab-panels/CitationPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/CitationPanel.tsx
@@ -46,8 +46,14 @@ const CitationPanel = () => {
     [context.collection]
   );
   const otherConstraints = useMemo(
-    () => context.collection?.getCitation()?.otherConstraints,
-    [context.collection]
+    () =>
+      context.collection?.getCitation()?.otherConstraints?.filter(
+        // Some organizations put license in "other constraints".
+        // So if a constraint is considered as license by es-indexer,
+        // we should not show it in "other constraints".
+        (cons) => cons.toLowerCase().trim() !== license?.toLowerCase().trim()
+      ),
+    [context.collection, license]
   );
   const useLimitations = useMemo(
     () => context.collection?.getCitation()?.useLimitations,


### PR DESCRIPTION
Solution for this comment: https://github.com/aodn/backlog/issues/5704#issuecomment-2277160625

For example this record: [050ca30f-1448-46f9-b985-02c7991ac355](https://portal-edge.aodn.org.au/details?uuid=050ca30f-1448-46f9-b985-02c7991ac355)   . license and one item in the "other constraint" are showing the same content. In addition, there is a broken image "license graphic". After fixing, the duplicated constraint won't show, and if there is no license graphic, no broken image.