### PR TITLE
Feature/5659 change metadata info display

### DIFF
--- a/src/components/list/LicenseList.tsx
+++ b/src/components/list/LicenseList.tsx
@@ -13,7 +13,7 @@ const LicenseList: React.FC<LicenseListProps> = ({ license, url, graphic }) => {
   const theme = useTheme();
   const licenseComponent = useMemo(() => {
     return (
-      <StyledItemGrid container>
+      <StyledItemGrid container key="licenseList">
         <Grid container item md={12}>
           <Grid item md={12}>
             <Typography variant="detailContent">{license}</Typography>

--- a/src/components/list/MetadataContactList.tsx
+++ b/src/components/list/MetadataContactList.tsx
@@ -7,12 +7,10 @@ import { Grid, Link, Typography, useTheme } from "@mui/material";
 import MailOutlineIcon from "@mui/icons-material/MailOutline";
 
 interface MetadataContactListProps {
-  title: string;
   contacts: IContact[];
 }
 
 const MetadataContactList: React.FC<MetadataContactListProps> = ({
-  title,
   contacts,
 }) => {
   const theme = useTheme();
@@ -47,7 +45,9 @@ const MetadataContactList: React.FC<MetadataContactListProps> = ({
     return contactsToAdd;
   }, [contacts, theme.mp.md]);
 
-  return <ExpandableList title={title} childrenList={metadataContacts} />;
+  return (
+    <ExpandableList title="Metadata Contact" childrenList={metadataContacts} />
+  );
 };
 
 export default MetadataContactList;

--- a/src/components/list/MetadataContactList.tsx
+++ b/src/components/list/MetadataContactList.tsx
@@ -1,0 +1,53 @@
+import { IContact } from "../common/store/OGCCollectionDefinitions";
+import React, { ReactNode, useMemo } from "react";
+import TextItem from "./listItem/TextItem";
+import ContactArea from "./listItem/subitem/ContactArea";
+import ExpandableList from "./ExpandableList";
+import { Grid, Link, Typography, useTheme } from "@mui/material";
+import MailOutlineIcon from "@mui/icons-material/MailOutline";
+
+interface MetadataContactListProps {
+  title: string;
+  contacts: IContact[];
+}
+
+const MetadataContactList: React.FC<MetadataContactListProps> = ({
+  title,
+  contacts,
+}) => {
+  const theme = useTheme();
+  const metadataContacts: ReactNode[] = useMemo(() => {
+    const contactsToAdd: ReactNode[] = [];
+    contacts?.map((contact, index) => {
+      const suffix = contact.name ? ` - ${contact.name}` : "";
+      contactsToAdd.push(
+        <TextItem key={index}>
+          <Grid item container md={12} sx={{ marginBottom: theme.mp.md }}>
+            <Grid
+              item
+              container
+              md={1}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <MailOutlineIcon />
+            </Grid>
+            <Grid item md={11} sx={{ textAlign: "left", whiteSpace: "normal" }}>
+              <Link href={`mailto:${contact.emails[0]}`}>
+                <Typography variant="detailTitle">
+                  {contact.organization + suffix}
+                </Typography>
+              </Link>
+            </Grid>
+          </Grid>
+          <ContactArea contact={contact} />
+        </TextItem>
+      );
+    });
+    return contactsToAdd;
+  }, [contacts, theme.mp.md]);
+
+  return <ExpandableList title={title} childrenList={metadataContacts} />;
+};
+
+export default MetadataContactList;

--- a/src/components/list/MetadataDateList.tsx
+++ b/src/components/list/MetadataDateList.tsx
@@ -14,7 +14,7 @@ const MetadataDateList: React.FC<MetadataDateListProps> = ({
 }) => {
   const theme = useTheme();
   const metadataDateItem = (
-    <StyledItemGrid container>
+    <StyledItemGrid container key="Metadata date">
       {creation && (
         <Grid item md={12} sx={{ marginTop: theme.mp.sm }}>
           <Typography variant="detailContent">

--- a/src/components/list/MetadataDateList.tsx
+++ b/src/components/list/MetadataDateList.tsx
@@ -4,13 +4,11 @@ import StyledItemGrid from "./listItem/StyledItemGrid";
 import { Grid, Typography, useTheme } from "@mui/material";
 
 interface MetadataDateListProps {
-  title?: string;
   creation?: string;
   revision?: string;
 }
 
 const MetadataDateList: React.FC<MetadataDateListProps> = ({
-  title,
   creation,
   revision,
 }) => {
@@ -37,7 +35,9 @@ const MetadataDateList: React.FC<MetadataDateListProps> = ({
     </StyledItemGrid>
   );
 
-  return <ExpandableList childrenList={[metadataDateItem]} title={title} />;
+  return (
+    <ExpandableList childrenList={[metadataDateItem]} title="Metadata Dates" />
+  );
 };
 
 export default MetadataDateList;

--- a/src/components/list/MetadataDateList.tsx
+++ b/src/components/list/MetadataDateList.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import ExpandableList from "./ExpandableList";
+import StyledItemGrid from "./listItem/StyledItemGrid";
+import { Grid, Typography, useTheme } from "@mui/material";
+
+interface MetadataDateListProps {
+  title?: string;
+  creation?: string;
+  revision?: string;
+}
+
+const MetadataDateList: React.FC<MetadataDateListProps> = ({
+  title,
+  creation,
+  revision,
+}) => {
+  const theme = useTheme();
+  const metadataDateItem = (
+    <StyledItemGrid container>
+      {creation && (
+        <Grid item md={12} sx={{ marginTop: theme.mp.sm }}>
+          <Typography variant="detailContent">
+            <b>CREATION: </b>
+            {creation}
+          </Typography>
+        </Grid>
+      )}
+
+      {revision && (
+        <Grid item md={12} sx={{ marginTop: theme.mp.sm }}>
+          <Typography variant="detailContent">
+            <b>REVISION: </b>
+            {revision}
+          </Typography>
+        </Grid>
+      )}
+    </StyledItemGrid>
+  );
+
+  return <ExpandableList childrenList={[metadataDateItem]} title={title} />;
+};
+
+export default MetadataDateList;

--- a/src/components/list/MetadataUrlList.tsx
+++ b/src/components/list/MetadataUrlList.tsx
@@ -10,7 +10,7 @@ interface MetadataUrlListProps {
 const MetadataUrlList: React.FC<MetadataUrlListProps> = ({ url }) => {
   const link: ReactNode[] = [];
   link.push(
-    <TextItem>
+    <TextItem key={"url"}>
       <Link href={url} target="_blank" rel="noopener noreferrer">
         {url}
       </Link>

--- a/src/components/list/TextList.tsx
+++ b/src/components/list/TextList.tsx
@@ -7,8 +7,8 @@ interface TextListProps {
   texts: string[];
 }
 const TextList: React.FC<TextListProps> = ({ title, texts }) => {
-  const plainTextFragments: ReactNode[] = useMemo(() => {
-    const textFragmentList: ReactNode[] = [];
+  const textComponents: ReactNode[] = useMemo(() => {
+    const textsToAdd: ReactNode[] = [];
     texts?.map((text) => {
       const displayingText = [];
 
@@ -25,10 +25,10 @@ const TextList: React.FC<TextListProps> = ({ title, texts }) => {
         displayingText.push(text);
       }
 
-      textFragmentList.push(<TextItem key={text}>{displayingText}</TextItem>);
+      textsToAdd.push(<TextItem key={text}>{displayingText}</TextItem>);
     });
-    return textFragmentList;
+    return textsToAdd;
   }, [texts]);
-  return <ExpandableList title={title} childrenList={plainTextFragments} />;
+  return <ExpandableList title={title} childrenList={textComponents} />;
 };
 export default TextList;

--- a/src/components/list/listItem/subitem/TextArea.tsx
+++ b/src/components/list/listItem/subitem/TextArea.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { Grid, Typography } from "@mui/material";
+import { Grid, Typography, useTheme } from "@mui/material";
 
 interface TextAreaProps {
   children: React.ReactNode;
 }
 
 const TextArea: React.FC<TextAreaProps> = ({ children }) => {
+  const theme = useTheme();
   return (
-    <Grid item md={12}>
+    <Grid item md={12} sx={{ marginTop: theme.mp.sm }}>
       <Typography variant="detailContent">{children}</Typography>
     </Grid>
   );

--- a/src/pages/detail-page/README.md
+++ b/src/pages/detail-page/README.md
@@ -2,3 +2,9 @@
 
 Please name top level(e.g.: Abstract, About, Metadat Information ... ) "XXXpanel", (path: src/pages/detail-page/subpages/tab-panels)
 Please name second level (e.g.: keywords, contacts, credits...) "XXXList", (path: src/components/list)
+
+A list may not be a real list (show some similar things). It may only show one thing (such as metadata identifer). So please treat the name xxxList as a convention, to show the page structure:
+
+A panel contains one or several lists;
+
+A list contains one or several items;

--- a/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDetailPageContext } from "../../context/detail-page-context";
 import NavigatablePanel from "./NavigatablePanel";
 import TextList from "../../../../components/list/TextList";
 import { convertDateFormat } from "../../../../utils/DateUtils";
 import MetadataUrlList from "../../../../components/list/MetadataUrlList";
 import MetadataContactList from "../../../../components/list/MetadataContactList";
+import MetadataDateList from "../../../../components/list/MetadataDateList";
 
 const MetadataInformationPanel = () => {
   const context = useDetailPageContext();
@@ -19,25 +20,21 @@ const MetadataInformationPanel = () => {
         ?.filter((contact) => contact.roles.includes("metadata")),
     [context.collection]
   );
-  const generateMedatataDateText = useCallback(() => {
-    let dateText = "";
-
+  const creation = useMemo(() => {
     const creation = context.collection?.getCreation();
-    const revision = context.collection?.getRevision();
-
     if (creation) {
-      dateText = dateText + `Creation: ${convertDateFormat(creation)}`;
+      return convertDateFormat(creation);
     }
-    if (revision) {
-      if (dateText) {
-        dateText += "\n";
-      }
-      dateText = dateText + `Revision: ${convertDateFormat(revision)}`;
-    }
-    return dateText;
+    return "";
   }, [context.collection]);
 
-  const dates = useMemo(generateMedatataDateText, [generateMedatataDateText]);
+  const revision = useMemo(() => {
+    const revision = context.collection?.getRevision();
+    if (revision) {
+      return convertDateFormat(revision);
+    }
+    return "";
+  }, [context.collection]);
 
   const metadataLink = useMemo(() => {
     if (context.collection) {
@@ -94,11 +91,15 @@ const MetadataInformationPanel = () => {
       {
         title: "Metadata Dates",
         component: (
-          <TextList title="Metadata Dates" texts={dates ? [dates] : [""]} />
+          <MetadataDateList
+            title="Metadata Dates"
+            creation={creation}
+            revision={revision}
+          />
         ),
       },
     ],
-    [dates, metadataContact, metadataId, metadataLink]
+    [creation, metadataContact, metadataId, metadataLink, revision]
   );
   return <NavigatablePanel childrenList={blocks} isLoading={isLoading} />;
 };

--- a/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDetailPageContext } from "../../context/detail-page-context";
 import NavigatablePanel from "./NavigatablePanel";
-import ContactList from "../../../../components/list/ContactList";
 import TextList from "../../../../components/list/TextList";
 import { convertDateFormat } from "../../../../utils/DateUtils";
 import MetadataUrlList from "../../../../components/list/MetadataUrlList";
+import MetadataContactList from "../../../../components/list/MetadataContactList";
 
 const MetadataInformationPanel = () => {
   const context = useDetailPageContext();
@@ -72,9 +72,9 @@ const MetadataInformationPanel = () => {
       {
         title: "Metadata Contact",
         component: (
-          <ContactList
-            title="Metadata Contact"
+          <MetadataContactList
             contacts={metadataContact ? metadataContact : []}
+            title="Metadata Contact"
           />
         ),
       },

--- a/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/MetadataInformationPanel.tsx
@@ -71,7 +71,6 @@ const MetadataInformationPanel = () => {
         component: (
           <MetadataContactList
             contacts={metadataContact ? metadataContact : []}
-            title="Metadata Contact"
           />
         ),
       },
@@ -90,13 +89,7 @@ const MetadataInformationPanel = () => {
       },
       {
         title: "Metadata Dates",
-        component: (
-          <MetadataDateList
-            title="Metadata Dates"
-            creation={creation}
-            revision={revision}
-          />
-        ),
+        component: <MetadataDateList creation={creation} revision={revision} />,
       },
     ],
     [creation, metadataContact, metadataId, metadataLink, revision]


### PR DESCRIPTION
metadata contact is plain text now (not a collapsible area).
metadata dates' title was bolded and capitalized 