### PR TITLE
Disable logic to make result better

### DIFF
--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -165,17 +165,17 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
                 return phrasesSuggestions.has(item);
               }
             );
-
+            // TODO: This logic is error prone, need to fix this
             // check if the current inputValue is a common key or not, then dispatch updateCommonKey
-            if (
-              commonSuggestions.some(
-                (item) => item.toLowerCase() === inputValue.toLowerCase()
-              )
-            ) {
-              dispatch(updateCommonKey(inputValue));
-            } else {
-              dispatch(updateCommonKey(""));
-            }
+            // if (
+            //   commonSuggestions.some(
+            //     (item) => item.toLowerCase() === inputValue.toLowerCase()
+            //   )
+            // ) {
+            //   dispatch(updateCommonKey(inputValue));
+            // } else {
+            //   dispatch(updateCommonKey(""));
+            // }
 
             // Create array of all unique suggestions
             const allSuggestions = new Set([


### PR DESCRIPTION
We need a ticket to fix this search as it is confusing, basically when user type tempeature , it infer that it needs to search based on title, desc and parameter because one of the valid parameter is "temperature" 