### PR TITLE
hide the unimplemented elements temporarily

### DIFF
--- a/src/pages/detail-page/subpages/ContentSection.tsx
+++ b/src/pages/detail-page/subpages/ContentSection.tsx
@@ -36,11 +36,13 @@ const tabs = [
     value: "associated records",
     component: <AssociatedRecordsPanel />,
   },
-  {
-    label: "Global Attribute",
-    value: "Global Attribute",
-    component: <GlobalAttributePanel />,
-  },
+  //TODO: hide it now, for better demonstration. Will be added back (or delete)
+  // when have final decision on it
+  // {
+  //   label: "Global Attribute",
+  //   value: "Global Attribute",
+  //   component: <GlobalAttributePanel />,
+  // },
 ];
 
 const ContentSection: FC = () => {

--- a/src/pages/detail-page/subpages/HeaderSection.tsx
+++ b/src/pages/detail-page/subpages/HeaderSection.tsx
@@ -127,8 +127,9 @@ const HeaderSection = () => {
         }}
       >
         <Stack spacing={1}>
-          {renderButton(buttons.goToPrevious.icon)}
-          {renderButton(buttons.goToNext.icon)}
+          {/*TODO: hide the below 2 buttons now, for better demonstration. Can uncommented them when implementing them*/}
+          {/*{renderButton(buttons.goToPrevious.icon)}*/}
+          {/*{renderButton(buttons.goToNext.icon)}*/}
         </Stack>
       </Box>
       <Grid container>


### PR DESCRIPTION
the global attribute panel is hided, 
![image](https://github.com/user-attachments/assets/4399843d-0d81-4cec-8cd3-098320266321)

and the go previous & go next button also hided: 
![image](https://github.com/user-attachments/assets/8b345d53-76e0-4cea-90b9-276022a2e819)
