### PR TITLE
Bugfix/5895 fix layout shifting due to scrollbar disappearance

### DIFF
--- a/src/components/menu/HoverMenu.tsx
+++ b/src/components/menu/HoverMenu.tsx
@@ -64,7 +64,6 @@ const HoverMenu: React.FC<HoverMenuProps> = ({ menu }) => {
       >
         <ClickAwayListener onClickAway={handleClose}>
           <MenuList
-            autoFocusItem={open}
             onKeyDown={handleListKeyDown}
             onMouseEnter={() => setOpen(true)}
             onMouseLeave={() => setOpen(false)}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@ body {
   margin: 0;
   place-items: center;
   padding: 0 !important;
+  overflow-y: scroll !important;
 }
 
 h1 {

--- a/src/pages/landing-page/subpages/smartpanel/components/CardContainer.tsx
+++ b/src/pages/landing-page/subpages/smartpanel/components/CardContainer.tsx
@@ -25,7 +25,6 @@ const CardContainer: FC<CardContainerProps> = ({
       border: `${border.xs} ${color.brightBlue.semiTransparentDark}`,
       color: "#fff",
       "&:hover": {
-        scale: "101%",
         cursor: "pointer",
       },
       ...containerStyle,

--- a/src/pages/landing-page/subpages/smartpanel/components/LargeCard.tsx
+++ b/src/pages/landing-page/subpages/smartpanel/components/LargeCard.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { CardData } from "../constants";
 import CardContainer from "./CardContainer";
 import { Box, Typography } from "@mui/material";
@@ -15,6 +15,8 @@ interface LargeCardProps {
 }
 
 const LargeCard: FC<LargeCardProps> = ({ cardData, handleClickSmartCard }) => {
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
   const handleClick = (value: string) => {
     if (!cardData.disable) handleClickSmartCard(value);
   };
@@ -34,8 +36,16 @@ const LargeCard: FC<LargeCardProps> = ({ cardData, handleClickSmartCard }) => {
           backgroundPosition: "center",
           backgroundSize: "cover",
         }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
-        <Typography variant="h6">{cardData.title}</Typography>
+        <Typography
+          variant="h6"
+          fontWeight={isHovered ? fontWeight.bold : fontWeight.regular}
+          onClick={() => handleClick(cardData.title)}
+        >
+          {cardData.title}
+        </Typography>
       </Box>
       <Box
         display="flex"

--- a/src/pages/landing-page/subpages/smartpanel/components/MediumCard.tsx
+++ b/src/pages/landing-page/subpages/smartpanel/components/MediumCard.tsx
@@ -1,7 +1,8 @@
 import { Box, Typography } from "@mui/material";
-import { FC } from "react";
+import { FC, useState } from "react";
 import { CardData } from "../constants";
 import CardContainer from "./CardContainer";
+import { fontWeight } from "../../../../../styles/constants";
 
 interface MediumCardProps {
   cardData: CardData;
@@ -12,6 +13,8 @@ const MediumCard: FC<MediumCardProps> = ({
   cardData,
   handleClickSmartCard,
 }) => {
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
   const handleClick = (value: string) => {
     if (!cardData.disable) handleClickSmartCard(value);
   };
@@ -25,8 +28,16 @@ const MediumCard: FC<MediumCardProps> = ({
         backgroundSize: "cover",
       }}
     >
-      <Box onClick={() => handleClick(cardData.title)}>
-        <Typography padding={0} variant="h6">
+      <Box
+        onClick={() => handleClick(cardData.title)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <Typography
+          padding={0}
+          variant="h6"
+          fontWeight={isHovered ? fontWeight.bold : fontWeight.regular}
+        >
           {cardData.title}
         </Typography>
       </Box>

--- a/src/pages/landing-page/subpages/smartpanel/components/SmallCard.tsx
+++ b/src/pages/landing-page/subpages/smartpanel/components/SmallCard.tsx
@@ -1,8 +1,8 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { CardData } from "../constants";
 import CardContainer from "./CardContainer";
-import { fontSize, padding } from "../../../../../styles/constants";
+import { fontSize, fontWeight, padding } from "../../../../../styles/constants";
 
 interface SmallCardProps {
   cardData: CardData;
@@ -10,6 +10,8 @@ interface SmallCardProps {
 }
 
 const SmallCard: FC<SmallCardProps> = ({ cardData, handleClickSmartCard }) => {
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
   const handleClick = (value: string) => {
     if (!cardData.disable) handleClickSmartCard(value);
   };
@@ -21,6 +23,8 @@ const SmallCard: FC<SmallCardProps> = ({ cardData, handleClickSmartCard }) => {
         width="50%"
         padding={padding.extraSmall}
         onClick={() => handleClick(cardData.title)}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
         <img
           src={cardData.icon}
@@ -29,6 +33,7 @@ const SmallCard: FC<SmallCardProps> = ({ cardData, handleClickSmartCard }) => {
             objectFit: "contain",
             width: "100%",
             height: "100%",
+            scale: isHovered ? "105%" : "none",
           }}
         />
       </Box>
@@ -37,6 +42,7 @@ const SmallCard: FC<SmallCardProps> = ({ cardData, handleClickSmartCard }) => {
         paddingTop={0}
         fontSize={fontSize.icon}
         color="#fff"
+        fontWeight={isHovered ? fontWeight.bold : fontWeight.regular}
         sx={{
           overflow: "hidden",
         }}


### PR DESCRIPTION
MUI components like Select, Menu, Dialog or Backdrop will create a new dom within body instead of the parent component (so that it can ignore the background when the component pop over), resulting in layout shifting due to the disappearance of the scroll bar.  
So I changed the index.css to make the scroll bar to always be visible to get rid of the layout shifting issue, which is common in web design (case of [jbhifi](https://www.jbhifi.com.au/) : when you hit any drop down select you will see there is always a placeholder for scroll bar on the right side)