### PR TITLE
Feature/5918 not found UUID record page

### DIFF
--- a/src/components/common/dropdown/CommonSelect.tsx
+++ b/src/components/common/dropdown/CommonSelect.tsx
@@ -7,6 +7,7 @@ import {
 } from "@mui/material";
 import { FC, useState } from "react";
 import { IconProps } from "../../icon/types";
+import { useDetailPageContext } from "../../../pages/detail-page/context/detail-page-context";
 
 export interface SelectItem<T = string> {
   value: T;
@@ -17,7 +18,6 @@ export interface CommonSelectProps<T = string> {
   items: SelectItem<T>[];
   onSelectCallback?: (value: T) => void;
   sx?: SxProps;
-  disabled?: boolean;
 }
 
 const DEFAULT_SELECT_STYLE: SxProps = {
@@ -37,9 +37,9 @@ const CommonSelect: FC<CommonSelectProps> = ({
   items,
   onSelectCallback,
   sx,
-  disabled = false,
 }) => {
   const [selectedItem, setSelectedItem] = useState<string>(items[0].value);
+  const { isCollectionNotFound } = useDetailPageContext();
 
   const handleOnChange = (event: SelectChangeEvent<string>) => {
     const selectedItem = event.target.value as string;
@@ -48,7 +48,7 @@ const CommonSelect: FC<CommonSelectProps> = ({
   };
 
   return (
-    <FormControl fullWidth disabled={disabled}>
+    <FormControl fullWidth disabled={isCollectionNotFound}>
       <Select
         value={selectedItem}
         onChange={handleOnChange}

--- a/src/components/common/dropdown/CommonSelect.tsx
+++ b/src/components/common/dropdown/CommonSelect.tsx
@@ -17,6 +17,7 @@ export interface CommonSelectProps<T = string> {
   items: SelectItem<T>[];
   onSelectCallback?: (value: T) => void;
   sx?: SxProps;
+  disabled?: boolean;
 }
 
 const DEFAULT_SELECT_STYLE: SxProps = {
@@ -36,6 +37,7 @@ const CommonSelect: FC<CommonSelectProps> = ({
   items,
   onSelectCallback,
   sx,
+  disabled = false,
 }) => {
   const [selectedItem, setSelectedItem] = useState<string>(items[0].value);
 
@@ -46,7 +48,7 @@ const CommonSelect: FC<CommonSelectProps> = ({
   };
 
   return (
-    <FormControl fullWidth>
+    <FormControl fullWidth disabled={disabled}>
       <Select
         value={selectedItem}
         onChange={handleOnChange}

--- a/src/components/details/TabsPanelContainer.tsx
+++ b/src/components/details/TabsPanelContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
+import { useEffect } from "react";
 import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
+import Tab, { TabProps } from "@mui/material/Tab";
 import Box from "@mui/material/Box";
 import {
   border,
@@ -21,6 +22,7 @@ interface Tab {
 
 interface TabsPanelProps {
   tabs: Tab[];
+  isCollectionNotFound: boolean;
 }
 
 interface TabPanelProps {
@@ -52,7 +54,17 @@ function a11yProps(index: number) {
   };
 }
 
-const TabsPanelContainer: React.FC<TabsPanelProps> = ({ tabs }) => {
+const TabsPanelContainer: React.FC<TabsPanelProps> = ({
+  tabs,
+  isCollectionNotFound,
+}) => {
+  // if no collection found, unfocus the tab
+  useEffect(() => {
+    if (isCollectionNotFound) {
+      setValue(-1);
+    }
+  }, [isCollectionNotFound]);
+
   const [value, setValue] = React.useState(0);
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -76,6 +88,7 @@ const TabsPanelContainer: React.FC<TabsPanelProps> = ({ tabs }) => {
             label={tab.label}
             {...a11yProps(index)}
             sx={{ textTransform: "none" }}
+            disabled={isCollectionNotFound}
           />
         ))}
       </StyledTabs>
@@ -121,21 +134,17 @@ const StyledTabs = styled((props: StyledTabsProps) => (
   },
 });
 
-interface StyledTabProps {
-  label: string;
-}
-
-const StyledTab = styled((props: StyledTabProps) => (
+const StyledTab = styled((props: TabProps) => (
   <Tab
     disableRipple
     {...props}
     sx={{ margin: `${margin.xxlg} ${margin.lg}` }}
   />
-))(({ theme }) => ({
+))(({ theme, disabled }) => ({
   textTransform: "none",
   fontWeight: fontWeight.regular,
   color: fontColor.gray.dark,
-  border: `${border.xs}  ${color.tabPanel.tabOnFocused}`,
+  border: `${border.xs}  ${disabled ? "#AAA" : color.tabPanel.tabOnFocused}`,
   borderRadius: borderRadius.xxlg,
   "&.Mui-selected": {
     color: "#fff",

--- a/src/components/details/TabsPanelContainer.tsx
+++ b/src/components/details/TabsPanelContainer.tsx
@@ -13,6 +13,7 @@ import {
   padding,
 } from "../../styles/constants";
 import { styled } from "@mui/material";
+import { useDetailPageContext } from "../../pages/detail-page/context/detail-page-context";
 
 interface Tab {
   label: string;
@@ -22,7 +23,6 @@ interface Tab {
 
 interface TabsPanelProps {
   tabs: Tab[];
-  isCollectionNotFound: boolean;
 }
 
 interface TabPanelProps {
@@ -54,10 +54,8 @@ function a11yProps(index: number) {
   };
 }
 
-const TabsPanelContainer: React.FC<TabsPanelProps> = ({
-  tabs,
-  isCollectionNotFound,
-}) => {
+const TabsPanelContainer: React.FC<TabsPanelProps> = ({ tabs }) => {
+  const { isCollectionNotFound } = useDetailPageContext();
   // if no collection found, unfocus the tab
   useEffect(() => {
     if (isCollectionNotFound) {

--- a/src/pages/detail-page/context/detail-page-context.tsx
+++ b/src/pages/detail-page/context/detail-page-context.tsx
@@ -8,6 +8,7 @@ export interface SpatialExtentPhoto {
 interface DetailPageContextType {
   collection: OGCCollection | undefined;
   setCollection: Dispatch<SetStateAction<OGCCollection | undefined>>;
+  isCollectionNotFound: boolean;
   photos: SpatialExtentPhoto[];
   setPhotos: Dispatch<SetStateAction<SpatialExtentPhoto[]>>;
   extentsPhotos: SpatialExtentPhoto[] | undefined;
@@ -23,6 +24,7 @@ interface DetailPageContextType {
 const DetailPageContextDefault = {
   collection: {} as OGCCollection | undefined,
   setCollection: () => {},
+  isCollectionNotFound: true,
   photos: [] as SpatialExtentPhoto[],
   setPhotos: () => {},
   extentsPhotos: [] as SpatialExtentPhoto[],

--- a/src/pages/detail-page/context/detail-page-context.tsx
+++ b/src/pages/detail-page/context/detail-page-context.tsx
@@ -24,7 +24,7 @@ interface DetailPageContextType {
 const DetailPageContextDefault = {
   collection: {} as OGCCollection | undefined,
   setCollection: () => {},
-  isCollectionNotFound: true,
+  isCollectionNotFound: false,
   photos: [] as SpatialExtentPhoto[],
   setPhotos: () => {},
   extentsPhotos: [] as SpatialExtentPhoto[],

--- a/src/pages/detail-page/context/detail-page-provider.tsx
+++ b/src/pages/detail-page/context/detail-page-provider.tsx
@@ -4,6 +4,7 @@ import { fetchResultByUuidNoStore } from "../../../components/common/store/searc
 import { DetailPageContext, SpatialExtentPhoto } from "./detail-page-context";
 import { OGCCollection } from "../../../components/common/store/OGCCollectionDefinitions";
 import { useAppDispatch } from "../../../components/common/store/hooks";
+import { HttpStatusCode } from "axios";
 
 interface DetailPageProviderProps {
   children: ReactNode;
@@ -17,6 +18,8 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
   const [collection, setCollection] = useState<OGCCollection | undefined>(
     undefined
   );
+  const [isCollectionNotFound, setIsCollectionNotFound] =
+    useState<boolean>(false);
   const [photos, setPhotos] = useState<SpatialExtentPhoto[]>([]);
   const [extentsPhotos, setExtentsPhotos] = useState<SpatialExtentPhoto[]>([]);
   const [photoHovered, setPhotoHovered] = useState<SpatialExtentPhoto>();
@@ -40,6 +43,11 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
       .unwrap()
       .then((collection) => {
         setCollection(collection);
+      })
+      .catch((error) => {
+        if (error.statusCode && error.statusCode === HttpStatusCode.NotFound) {
+          setIsCollectionNotFound(true);
+        }
       });
   }, [dispatch, location.search]);
 
@@ -48,6 +56,7 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
       value={{
         collection,
         setCollection,
+        isCollectionNotFound,
         photos,
         setPhotos,
         extentsPhotos,

--- a/src/pages/detail-page/context/detail-page-provider.tsx
+++ b/src/pages/detail-page/context/detail-page-provider.tsx
@@ -43,6 +43,7 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
       .unwrap()
       .then((collection) => {
         setCollection(collection);
+        setIsCollectionNotFound(false);
       })
       .catch((error) => {
         if (error.statusCode && error.statusCode === HttpStatusCode.NotFound) {

--- a/src/pages/detail-page/subpages/ContentSection.tsx
+++ b/src/pages/detail-page/subpages/ContentSection.tsx
@@ -6,10 +6,11 @@ import { FC } from "react";
 import AbstractAndDownloadPanel from "./tab-panels/AbstractAndDownloadPanel";
 import LineagePanel from "./tab-panels/LineagePanel";
 import AssociatedRecordsPanel from "./tab-panels/AssociatedRecordsPanel";
-import GlobalAttributePanel from "./tab-panels/GlobalAttributePanel";
 import TabsPanelContainer from "../../../components/details/TabsPanelContainer";
-import { Card } from "@mui/material";
+import { Card, Grid } from "@mui/material";
 import { borderRadius } from "../../../styles/constants";
+import { useDetailPageContext } from "../context/detail-page-context";
+import RecordNotFoundPanel from "./tab-panels/RecordNotFoundPanel";
 
 const tabs = [
   {
@@ -46,6 +47,7 @@ const tabs = [
 ];
 
 const ContentSection: FC = () => {
+  const { isCollectionNotFound } = useDetailPageContext();
   return (
     <Card
       sx={{
@@ -53,7 +55,15 @@ const ContentSection: FC = () => {
         borderRadius: borderRadius.small,
       }}
     >
-      <TabsPanelContainer tabs={tabs} />
+      <TabsPanelContainer
+        tabs={tabs}
+        isCollectionNotFound={isCollectionNotFound}
+      />
+      {isCollectionNotFound && (
+        <Grid container sx={{ height: "1000px" }}>
+          <RecordNotFoundPanel />
+        </Grid>
+      )}
     </Card>
   );
 };

--- a/src/pages/detail-page/subpages/ContentSection.tsx
+++ b/src/pages/detail-page/subpages/ContentSection.tsx
@@ -55,10 +55,7 @@ const ContentSection: FC = () => {
         borderRadius: borderRadius.small,
       }}
     >
-      <TabsPanelContainer
-        tabs={tabs}
-        isCollectionNotFound={isCollectionNotFound}
-      />
+      <TabsPanelContainer tabs={tabs} />
       {isCollectionNotFound && (
         <Grid container sx={{ height: "1000px" }}>
           <RecordNotFoundPanel />

--- a/src/pages/detail-page/subpages/SideSection.tsx
+++ b/src/pages/detail-page/subpages/SideSection.tsx
@@ -6,8 +6,10 @@ import SpatialCoverageCard from "./side-cards/SpatialCoverageCard";
 import TimePeriodCard from "./side-cards/TimePeriodCard";
 import ThemesCard from "./side-cards/ThemesCard";
 import RatingsAndCommentsCard from "./side-cards/RatingsAndCommentsCard";
+import { useDetailPageContext } from "../context/detail-page-context";
 
 const SideSection = () => {
+  const { isCollectionNotFound } = useDetailPageContext();
   return (
     <Stack direction="column" spacing={2}>
       <Card
@@ -18,11 +20,11 @@ const SideSection = () => {
       >
         <DownloadCard />
       </Card>
-      <OverviewCard />
-      <SpatialCoverageCard />
-      <TimePeriodCard />
-      <ThemesCard />
-      <RatingsAndCommentsCard />
+      {!isCollectionNotFound && <OverviewCard />}
+      {!isCollectionNotFound && <SpatialCoverageCard />}
+      {!isCollectionNotFound && <TimePeriodCard />}
+      {!isCollectionNotFound && <ThemesCard />}
+      {!isCollectionNotFound && <RatingsAndCommentsCard />}
     </Stack>
   );
 };

--- a/src/pages/detail-page/subpages/side-cards/DownloadCard.tsx
+++ b/src/pages/detail-page/subpages/side-cards/DownloadCard.tsx
@@ -20,10 +20,12 @@ import PlainAccordion from "../../../../components/common/accordion/PlainAccordi
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CommonSelect from "../../../../components/common/dropdown/CommonSelect";
 import { selects } from "../tab-panels/AbstractAndDownloadPanel";
+import { useDetailPageContext } from "../../context/detail-page-context";
 
 const DownloadCard = () => {
   const theme = useTheme();
   const [accordionExpanded, setAccordionExpanded] = useState<boolean>(false);
+  const { isCollectionNotFound } = useDetailPageContext();
 
   const selectSxProps = {
     height: "30px",
@@ -36,10 +38,17 @@ const DownloadCard = () => {
   return (
     <Stack direction="column">
       <Stack sx={{ padding: padding.medium }} spacing={2}>
-        <CommonSelect items={selects.download.options} sx={selectSxProps} />
+        <CommonSelect
+          items={selects.download.options}
+          sx={selectSxProps}
+          disabled={isCollectionNotFound}
+        />
         <Button
+          disabled={isCollectionNotFound}
           sx={{
-            backgroundColor: theme.palette.primary.main,
+            backgroundColor: isCollectionNotFound
+              ? "lightGrey"
+              : theme.palette.primary.main,
             borderRadius: borderRadius.small,
             ":hover": {
               backgroundColor: theme.palette.primary.main,
@@ -58,6 +67,7 @@ const DownloadCard = () => {
         onChange={() => setAccordionExpanded((prevState) => !prevState)}
       >
         <AccordionSummary
+          disabled={isCollectionNotFound}
           sx={{ paddingX: padding.medium }}
           expandIcon={<ExpandMoreIcon />}
         >

--- a/src/pages/detail-page/subpages/side-cards/DownloadCard.tsx
+++ b/src/pages/detail-page/subpages/side-cards/DownloadCard.tsx
@@ -38,11 +38,7 @@ const DownloadCard = () => {
   return (
     <Stack direction="column">
       <Stack sx={{ padding: padding.medium }} spacing={2}>
-        <CommonSelect
-          items={selects.download.options}
-          sx={selectSxProps}
-          disabled={isCollectionNotFound}
-        />
+        <CommonSelect items={selects.download.options} sx={selectSxProps} />
         <Button
           disabled={isCollectionNotFound}
           sx={{

--- a/src/pages/detail-page/subpages/tab-panels/RecordNotFoundPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/RecordNotFoundPanel.tsx
@@ -17,9 +17,7 @@ const RecordNotFoundPanel = () => {
         backgroundColor: rgba,
         margin: theme.mp.xxlg,
         borderRadius: theme.borderRadius.sm,
-        // width: "99%",
         height: "120px",
-        // padding: `${theme.mp.sm} ${theme.mp.xlg}`,
         paddingY: theme.mp.xxlg,
         border: border,
       }}

--- a/src/pages/detail-page/subpages/tab-panels/RecordNotFoundPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/RecordNotFoundPanel.tsx
@@ -1,0 +1,53 @@
+import { Grid, hexToRgb, Typography, useTheme } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+
+const RecordNotFoundPanel = () => {
+  const theme = useTheme();
+  const uuid = new URLSearchParams(location.search).get("uuid");
+  const border = theme.border.detailNa.replace(
+    "#52BDEC",
+    theme.palette.warning.main
+  );
+
+  const rgba = alpha(hexToRgb(theme.palette.warning.main), 0.15);
+  return (
+    <Grid
+      container
+      sx={{
+        backgroundColor: rgba,
+        margin: theme.mp.xxlg,
+        borderRadius: theme.borderRadius.sm,
+        // width: "99%",
+        height: "120px",
+        // padding: `${theme.mp.sm} ${theme.mp.xlg}`,
+        paddingY: theme.mp.xxlg,
+        border: border,
+      }}
+    >
+      <Grid
+        item
+        md={12}
+        justifyContent="center"
+        display="flex"
+        alignContent="center"
+      >
+        <Typography variant="detailTitle" sx={{ fontWeight: 500 }}>
+          There is no matching result for &quot;{uuid}&quot;
+        </Typography>
+      </Grid>
+      <Grid
+        item
+        md={12}
+        justifyContent="center"
+        display="flex"
+        alignContent="center"
+      >
+        <Typography variant="detailTitle" sx={{ fontWeight: 500 }}>
+          Please check the related information
+        </Typography>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default RecordNotFoundPanel;

--- a/src/utils/AppTheme.ts
+++ b/src/utils/AppTheme.ts
@@ -107,13 +107,19 @@ const theme: ThemeOptions = {
       dark: "#2F4F6C",
     },
     info: {
-      main: "#000000",
-      light: "#000000",
+      main: "#000000", // not in use yet, so set to black
+      light: "#000000", // not in use yet, so set to black
       dark: "#3A6F8F",
     },
     common: {
       white: "#FFF",
       black: "#000",
+    },
+    warning: {
+      main: "#E76F51",
+      light: "#000000", // not in use yet, so set to black
+      dark: "#000000", // not in use yet, so set to black
+      contrastText: "#000000", // not in use yet, so set to black
     },
     success: {
       main: "#4CAF50",


### PR DESCRIPTION
currently, if there is no record matching the given uuid, will show such page: 
![image](https://github.com/user-attachments/assets/3efcb4d1-3f4a-45e6-a5f1-f56b4d73fe7a)


Didn't add tests for this feature, because too many mocked efforts need to do for the tests and it will possibly change in the future. 