### PR TITLE
:sparkles: improve clear text 'x' button

### DIFF
--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -263,9 +263,10 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
       sx={{
         ".MuiOutlinedInput-root": { padding: 0, paddingLeft: padding.small },
 
-        // Keep the clear text button 'X' always visible
+        // Keep the clear text button 'X' visible when there exists text input
         "& .MuiAutocomplete-clearIndicator": {
-          visibility: "visible",
+          visibility:
+            searchInput && searchInput.length > 0 ? "visible" : "hidden",
         },
       }}
       renderInput={(params) => (


### PR DESCRIPTION
before change: clear text 'X' button only appears when hovering on search bar input text field

after change:  clear text 'X' button is showing when hovering on text field or there exists input text. 