### PR TITLE
Bugs/6008 fix missing centroid

### DIFF
--- a/src/components/map/mapbox/layers/Layers.tsx
+++ b/src/components/map/mapbox/layers/Layers.tsx
@@ -29,23 +29,30 @@ const createStaticLayers = (ids: Array<string>) => (
     })}
   </>
 );
+
+const normalizeLongitude = (lng: number) =>
+  ((((lng + 180) % 360) + 360) % 360) - 180;
+
 // Use to handle bounds across meridian
 const splitLngLatBounds = (bounds: LngLatBounds): Array<LngLatBounds> => {
   const sw = bounds.getSouthWest(); // Southwest corner
   const ne = bounds.getNorthEast(); // Northeast corner
 
+  // We need to make it between -180 to 180 for checking
+  const normalNeLng = normalizeLongitude(ne.lng);
+  const normalSwLng = normalizeLongitude(sw.lng);
   // Check if the bounds cross the anti-meridian
-  if (ne.lng < sw.lng) {
+  if (normalNeLng < normalSwLng) {
     // Split into two parts: one from -180 to 180 and one from 180 to -180
 
     const leftBounds = new LngLatBounds(
-      new LngLat(sw.lng, sw.lat), // Left side (from -180 to 180)
+      new LngLat(normalSwLng, sw.lat), // Left side (from -180 to 180)
       new LngLat(180, ne.lat)
     );
 
     const rightBounds = new LngLatBounds(
       new LngLat(-180, sw.lat), // Right side (from 180 to -180)
-      new LngLat(ne.lng, ne.lat)
+      new LngLat(normalNeLng, ne.lat)
     );
 
     return [leftBounds, rightBounds];

--- a/src/components/map/mapbox/layers/__test__/Layers.nomapmock.test.tsx
+++ b/src/components/map/mapbox/layers/__test__/Layers.nomapmock.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { Feature, FeatureCollection, GeoJsonProperties, Point } from "geojson";
+import { findSuitableVisiblePoint, isFeatureVisible } from "../Layers";
+import * as turf from "@turf/turf";
+import { LngLatBounds } from "mapbox-gl";
+
+// Define the test where we do not need to mock the Map
+describe("Test case where no map mock needed", () => {
+  it("should return the same feature collection if no map is provided", () => {
+    const featureCollection: FeatureCollection<Point> = {
+      type: "FeatureCollection",
+      features: [],
+    };
+
+    const result = findSuitableVisiblePoint(featureCollection, null);
+
+    // Expect the same input to be returned since the map is null
+    expect(result).toEqual(featureCollection);
+  });
+
+  it("verfiy anti-meridian works for isFeatureVisible", () => {
+    // The point value isn't too important as long as it is below 180 for x
+    const target: Feature<Point, GeoJsonProperties> = {
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [158.72, -25.95],
+      },
+      properties: {
+        name: "Example Point",
+        description: "This is an example of a GeoJSON Point Feature",
+      },
+    };
+
+    const bounds: LngLatBounds = new LngLatBounds([
+      [142.59, -46.021],
+      [203.4169, -10.956],
+    ]);
+    // We set a LngLat where x is < -180 to create anti-meridian
+    expect(isFeatureVisible(target, bounds)).toBeTruthy();
+  });
+});

--- a/src/components/map/mapbox/layers/__test__/Layers.nomapmock.test.tsx
+++ b/src/components/map/mapbox/layers/__test__/Layers.nomapmock.test.tsx
@@ -33,8 +33,8 @@ describe("Test case where no map mock needed", () => {
     };
 
     const bounds: LngLatBounds = new LngLatBounds([
-      [142.59, -46.021],
-      [203.4169, -10.956],
+      [-203.62, -43.828],
+      [-142.79, -8.759],
     ]);
     // We set a LngLat where x is < -180 to create anti-meridian
     expect(isFeatureVisible(target, bounds)).toBeTruthy();

--- a/src/components/map/mapbox/layers/__test__/Layers.test.tsx
+++ b/src/components/map/mapbox/layers/__test__/Layers.test.tsx
@@ -14,6 +14,8 @@ describe("findMostVisiblePoint", () => {
       return {
         ...actual,
         Map: vi.fn().mockImplementation(() => ({
+          // This is the current visible area of the map,
+          // we mock some random value to make test work
           getBounds: vi.fn().mockReturnValue({
             getSouthWest: () => [-203.62, -43.828],
             getNorthEast: () => [-142.79, -8.759],

--- a/src/components/map/mapbox/layers/__test__/Layers.test.tsx
+++ b/src/components/map/mapbox/layers/__test__/Layers.test.tsx
@@ -3,21 +3,33 @@ import { FeatureCollection, Point } from "geojson";
 import { findSuitableVisiblePoint } from "../Layers";
 import { Map } from "mapbox-gl";
 
-// Mock the MapboxGL Map class
-vi.mock("mapbox-gl", () => ({
-  Map: vi.fn().mockImplementation(() => ({
-    getBounds: vi.fn().mockReturnValue({
-      contains: vi.fn().mockReturnValue(true),
-    }),
-    getCenter: vi.fn().mockReturnValue({
-      lng: 0,
-      lat: 0,
-    }),
-  })),
-}));
-
 // Define the test
 describe("findMostVisiblePoint", () => {
+  beforeAll(() => {
+    // Mock the MapboxGL Map class
+    vi.mock("mapbox-gl", async () => {
+      const actual =
+        await vi.importActual<typeof import("mapbox-gl")>("mapbox-gl");
+
+      return {
+        ...actual,
+        Map: vi.fn().mockImplementation(() => ({
+          getBounds: vi.fn().mockReturnValue({
+            contains: vi.fn().mockReturnValue(true),
+          }),
+          getCenter: vi.fn().mockReturnValue({
+            lng: 0,
+            lat: 0,
+          }),
+        })),
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   it("should return the most visible and closest points by uuid", () => {
     // Define a mock feature collection
     const featureCollection: FeatureCollection<Point> = {
@@ -91,17 +103,5 @@ describe("findMostVisiblePoint", () => {
 
     // Expect the result to match the expected output
     expect(result).toEqual(expected);
-  });
-
-  it("should return the same feature collection if no map is provided", () => {
-    const featureCollection: FeatureCollection<Point> = {
-      type: "FeatureCollection",
-      features: [],
-    };
-
-    const result = findSuitableVisiblePoint(featureCollection, null);
-
-    // Expect the same input to be returned since the map is null
-    expect(result).toEqual(featureCollection);
   });
 });

--- a/src/components/map/mapbox/layers/__test__/Layers.test.tsx
+++ b/src/components/map/mapbox/layers/__test__/Layers.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { FeatureCollection, Point } from "geojson";
 import { findSuitableVisiblePoint } from "../Layers";
-import { Map } from "mapbox-gl";
+import { LngLatBounds, Map } from "mapbox-gl";
 
 // Define the test
 describe("findMostVisiblePoint", () => {
@@ -15,6 +15,8 @@ describe("findMostVisiblePoint", () => {
         ...actual,
         Map: vi.fn().mockImplementation(() => ({
           getBounds: vi.fn().mockReturnValue({
+            getSouthWest: () => [-203.62, -43.828],
+            getNorthEast: () => [-142.79, -8.759],
             contains: vi.fn().mockReturnValue(true),
           }),
           getCenter: vi.fn().mockReturnValue({


### PR DESCRIPTION
Fix issue on calculate if centroid is visible across meridian that is -203 for lng etc

You can test it by finding a spatial extents that is close to 180 <> -180 line and then move the map to right but still able to see the spatial extents. The dot should still fail inside the spatial extents