### PR TITLE
:zap: change text search words joining method

### DIFF
--- a/src/components/common/store/componentParamReducer.tsx
+++ b/src/components/common/store/componentParamReducer.tsx
@@ -4,7 +4,7 @@
  */
 import { bboxPolygon } from "@turf/turf";
 import { Feature, Polygon, GeoJsonProperties } from "geojson";
-import { DatasetFrequency, mergeToSearchText } from "./searchReducer";
+import { DatasetFrequency } from "./searchReducer";
 import { MapDefaultConfig } from "../../map/mapbox/constants";
 
 const UPDATE_PARAMETER_STATES = "UPDATE_PARAMETER_STATES";

--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -330,7 +330,7 @@ const createSearchParamFrom = (
   // TODO: need to remove this block if ogcapi support platform filter
   const searchTerms = mergeToSearchText(i.platform, i.searchText);
   if (searchTerms.length > 0) {
-    p.text = searchTerms.join(" ");
+    p.text = searchTerms.join(",");
   }
 
   const c = mergeWithDefaults(


### PR DESCRIPTION
after change:
```
{
    "sortby": "id",
    "text": "satellite,glider,gloat,moorings-buoy",
    "filter": "BBOX(geometry,121.26123046876307,-39.919735388847585,145.7387695312375,-11.080264611153755)",
    "properties": "id,centroid"
}
```