### PR TITLE
Limited number of record return on map

### DIFF
--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -63,6 +63,7 @@ interface ObjectValue {
   parameterVocabsResult: Array<Vocab>;
 }
 export const DEFAULT_SEARCH_PAGE_SIZE = 11;
+export const DEFAULT_SEARCH_MAP_SIZE = 1500;
 export const FULL_LIST_PAGE_SIZE = 21;
 
 const DEFAULT_SEARCH_SCORE = import.meta.env.VITE_ELASTIC_RELEVANCE_SCORE;

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -6,6 +6,7 @@ import { bboxPolygon, booleanEqual } from "@turf/turf";
 import store, { getComponentState } from "../../components/common/store/store";
 import {
   createSearchParamFrom,
+  DEFAULT_SEARCH_MAP_SIZE,
   DEFAULT_SEARCH_PAGE_SIZE,
   fetchResultNoStore,
   fetchResultWithStore,
@@ -131,6 +132,7 @@ const SearchPage = () => {
     // it is ok to exclude it because it isn't show on map anyway
     const paramNonPaged = createSearchParamFrom(componentParam, {
       includeNoSpatialExtents: false,
+      pagesize: DEFAULT_SEARCH_MAP_SIZE,
     });
     const collections = await dispatch(
       // add param "sortby: id" for fetchResultNoStore to ensure data source for map is always sorted


### PR DESCRIPTION
It takes too long for search without any search criteria, it is better to limited the number of record return to speed up the system.