### PR TITLE
:lipstick: display full title

### DIFF
--- a/src/components/common/buttons/ResultCardButton.tsx
+++ b/src/components/common/buttons/ResultCardButton.tsx
@@ -1,11 +1,15 @@
 import { ElementType, FC, isValidElement } from "react";
 import { Button, SxProps, Tooltip, Typography } from "@mui/material";
-import { color, fontSize, padding } from "../../../styles/constants";
+import { color, padding } from "../../../styles/constants";
 import { mergeWithDefaults } from "../../../utils/ObjectUtils";
 
-interface ResultCardButtonConfig {
+export enum ResultCardButtonSize {
+  SMALL = "small",
+  MEDIUM = "medium",
+}
+export interface ResultCardButtonConfig {
   color?: string;
-  size?: string;
+  size?: ResultCardButtonSize;
 }
 
 interface ResultCardButtonProps {
@@ -20,7 +24,7 @@ interface ResultCardButtonProps {
 
 const defaultResultCardButtonConfig: ResultCardButtonConfig = {
   color: color.blue.dark,
-  size: "small",
+  size: ResultCardButtonSize.MEDIUM,
 };
 
 const ResultCardButton: FC<ResultCardButtonProps> = ({
@@ -53,14 +57,19 @@ const ResultCardButton: FC<ResultCardButtonProps> = ({
         {isValidElement(startIcon) ? (
           startIcon
         ) : (
-          <IconComponent fontSize="small" sx={{ color: config.color }} />
+          <IconComponent
+            sx={{
+              color: config.color,
+              fontSize: config.size === "small" ? "14px" : "18px",
+            }}
+          />
         )}
 
         {text && !shouldHideText && (
           <Typography
             padding={0}
             pl={padding.extraSmall}
-            fontSize={config.size === "small" ? fontSize.label : fontSize.icon}
+            fontSize={config.size === "small" ? "12px" : "14px"}
             color={
               config.color === "success" ? color.success.main : config.color
             }

--- a/src/components/common/buttons/ResultCardButton.tsx
+++ b/src/components/common/buttons/ResultCardButton.tsx
@@ -24,7 +24,7 @@ interface ResultCardButtonProps {
 
 const defaultResultCardButtonConfig: ResultCardButtonConfig = {
   color: color.blue.dark,
-  size: ResultCardButtonSize.MEDIUM,
+  size: ResultCardButtonSize.SMALL,
 };
 
 const ResultCardButton: FC<ResultCardButtonProps> = ({

--- a/src/components/common/hover-tip/ComplexMapHoverTip.tsx
+++ b/src/components/common/hover-tip/ComplexMapHoverTip.tsx
@@ -98,7 +98,7 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
           onDownload={onDownload}
           onDetail={onDetail}
         />
-        <Box height="auto">
+        <Box>
           <Typography
             color={fontColor.gray.medium}
             fontSize={fontSize.resultCardContent}
@@ -107,9 +107,6 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
               paddingX: padding.small,
               overflow: "hidden",
               textOverflow: "ellipsis",
-              display: "-webkit-box",
-              WebkitLineClamp: "4",
-              WebkitBoxOrient: "vertical",
               wordBreak: "break-word",
             }}
           >

--- a/src/components/common/hover-tip/ComplexMapHoverTip.tsx
+++ b/src/components/common/hover-tip/ComplexMapHoverTip.tsx
@@ -5,6 +5,7 @@ import {
   fontColor,
   fontSize,
   fontWeight,
+  gap,
   padding,
 } from "../../../styles/constants";
 import ResultCardButtonGroup from "../../result/ResultCardButtonGroup";
@@ -49,34 +50,30 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
   return (
     <Box flex={1} sx={{ ...sx }}>
       <Stack direction="column" spacing={1}>
-        <Box>
+        <Box position="relative">
           <Tooltip title={collection.title} placement="top">
             <Box
               display="flex"
               alignItems="center"
               justifyContent="space-between"
-              height="60px"
+              height="auto"
+              width="90%"
             >
               <Typography
                 fontWeight={fontWeight.bold}
-                fontSize={fontSize.info}
+                fontSize={fontSize.label}
                 sx={{
                   padding: 0,
                   overflow: "hidden",
                   textOverflow: "ellipsis",
                   display: "-webkit-box",
-                  WebkitLineClamp: "3",
+                  WebkitLineClamp: "5",
                   WebkitBoxOrient: "vertical",
                 }}
               >
                 {collection.title}
               </Typography>
-              <Box
-                display="flex"
-                alignItems="start"
-                justifyContent="center"
-                height="100%"
-              >
+              <Box position="absolute" top={gap.xs} right={gap.xs}>
                 <BookmarkButton dataset={collection} />
               </Box>
             </Box>
@@ -85,10 +82,8 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
         <Box
           arial-label="map"
           id={`${mapContainerId}-${collection.id}`}
-          sx={{
-            width: "100%",
-            height: "130px",
-          }}
+          width="100%"
+          height="130px"
         >
           <Map panelId={`${mapContainerId}-${collection.id}`} animate={false}>
             <Layers>
@@ -103,25 +98,23 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
           onDownload={onDownload}
           onDetail={onDetail}
         />
-        <Box>
-          <Tooltip title="More detail..." placement="top">
-            <Typography
-              color={fontColor.gray.medium}
-              fontSize={fontSize.resultCardContent}
-              sx={{
-                padding: 0,
-                paddingX: padding.small,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                display: "-webkit-box",
-                WebkitLineClamp: "5",
-                WebkitBoxOrient: "vertical",
-                wordBreak: "break-word",
-              }}
-            >
-              {collection.description}
-            </Typography>
-          </Tooltip>
+        <Box height="auto">
+          <Typography
+            color={fontColor.gray.medium}
+            fontSize={fontSize.resultCardContent}
+            sx={{
+              padding: 0,
+              paddingX: padding.small,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              display: "-webkit-box",
+              WebkitLineClamp: "4",
+              WebkitBoxOrient: "vertical",
+              wordBreak: "break-word",
+            }}
+          >
+            {collection.description}
+          </Typography>
         </Box>
       </Stack>
     </Box>

--- a/src/components/map/mapbox/component/CardPopup.tsx
+++ b/src/components/map/mapbox/component/CardPopup.tsx
@@ -163,7 +163,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
           display: "flex",
           borderRadius: 0,
           marginTop: "auto",
-          height: "30%",
+          height: "auto",
           width: "100%",
           backgroundColor: "rgba(255, 255, 255, 0.9)",
           pointerEvents: "auto",
@@ -235,7 +235,6 @@ const CardPopup: React.FC<CardPopupProps> = ({
               onLinks={() => onLinks(content)}
               onDownload={() => onDownload(content)}
               onDetail={() => onDetail(content)}
-              resultCardButtonConfig={{ size: ResultCardButtonSize.SMALL }}
             />
           )}
         </CardContent>

--- a/src/components/map/mapbox/component/CardPopup.tsx
+++ b/src/components/map/mapbox/component/CardPopup.tsx
@@ -164,6 +164,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
           borderRadius: 0,
           marginTop: "auto",
           height: "auto",
+          maxHeight: "50%",
           width: "100%",
           backgroundColor: "rgba(255, 255, 255, 0.9)",
           pointerEvents: "auto",
@@ -191,6 +192,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
             position: "relative",
             width: isTablet ? "calc(100% - 250px)" : "100%",
             height: "auto",
+            maxHeight: "50%",
           }}
         >
           <Box position="absolute" sx={{ top: gap.md, right: gap.md }}>

--- a/src/components/map/mapbox/component/CardPopup.tsx
+++ b/src/components/map/mapbox/component/CardPopup.tsx
@@ -5,16 +5,15 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { Box, Card, CardContent, CardMedia, Typography } from "@mui/material";
 import { TabNavigation } from "../../../../hooks/useTabNavigation";
 import {
   fontColor,
   fontSize,
   fontWeight,
   gap,
-  padding,
   zIndex,
 } from "../../../../styles/constants";
-import { Box, Card, CardContent, CardMedia, Typography } from "@mui/material";
 import MapContext from "../MapContext";
 import { useAppDispatch } from "../../../common/store/hooks";
 import { fetchResultByUuidNoStore } from "../../../common/store/searchReducer";
@@ -28,6 +27,7 @@ import GeojsonLayer from "../layers/GeojsonLayer";
 import ResultCardButtonGroup from "../../../result/ResultCardButtonGroup";
 import { SEARCH_PAGE_REFERER } from "../../../../pages/search-page/constants";
 import BookmarkButton from "../../../bookmark/BookmarkButton";
+import { ResultCardButtonSize } from "../../../common/buttons/ResultCardButton";
 
 interface CardPopupProps {
   layerId: string;
@@ -42,7 +42,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
 }) => {
   const { map } = useContext(MapContext);
   const dispatch = useAppDispatch();
-  const { isUnderLaptop, isTablet } = useBreakpoint();
+  const { isUnderLaptop, isTablet, isMobile } = useBreakpoint();
   const panel = useRef<HTMLDivElement>(null);
   const [content, setContent] = useState<OGCCollection>(new OGCCollection());
 
@@ -78,15 +78,30 @@ const CardPopup: React.FC<CardPopupProps> = ({
   useEffect(() => {
     const onMouseClick = (ev: MapLayerMouseEvent): void => {
       if (ev.target && map && panel && panel.current) {
-        if (ev.features && ev.features.length > 0) {
-          const feature = ev.features[0] as Feature<Point>;
+        // Convert click coordinates to point for feature querying
+        const point = map.project(ev.lngLat);
+        // Query features from the specified layer at the clicked point
+        const features = point
+          ? map.queryRenderedFeatures(point, {
+              layers: [layerId],
+            })
+          : [];
+
+        // Check if we found any features at the clicked location
+        if (features && features.length > 0) {
+          const feature = features[0] as Feature<Point>;
           const uuid = feature?.properties?.uuid as string;
 
-          getCollectionData(uuid).then((collection) => {
-            collection && setContent(collection);
-          });
-          panel.current.style.visibility = "visible";
+          if (uuid) {
+            getCollectionData(uuid).then((collection) => {
+              collection && setContent(collection);
+            });
+            panel.current.style.visibility = "visible";
+          } else {
+            panel.current.style.visibility = "hidden";
+          }
         } else {
+          // If no features found (i.e. click in empty space), hide the popup
           panel.current.style.visibility = "hidden";
         }
       }
@@ -112,7 +127,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
     };
 
     if (isUnderLaptop) {
-      map?.on("click", layerId, onMouseClick);
+      map?.on("click", onMouseClick);
       map?.on("moveend", onMouseMoved);
       // Handle case when move out of map without leaving popup box
       // then do a search
@@ -120,7 +135,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
     }
 
     return () => {
-      map?.off("click", layerId, onMouseClick);
+      map?.off("click", onMouseClick);
       map?.off("moveend", onMouseMoved);
       map?.off("sourcedata", onSourceChange);
     };
@@ -175,6 +190,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
           sx={{
             position: "relative",
             width: isTablet ? "calc(100% - 250px)" : "100%",
+            height: "auto",
           }}
         >
           <Box position="absolute" sx={{ top: gap.md, right: gap.md }}>
@@ -182,14 +198,14 @@ const CardPopup: React.FC<CardPopupProps> = ({
           </Box>
           <Typography
             fontWeight={fontWeight.bold}
-            fontSize={fontSize.info}
+            fontSize={isMobile ? fontSize.label : fontSize.info}
             sx={{
               width: "95%",
               padding: 0,
               overflow: "hidden",
               textOverflow: "ellipsis",
               display: "-webkit-box",
-              WebkitLineClamp: "3",
+              WebkitLineClamp: "5",
               WebkitBoxOrient: "vertical",
             }}
           >
@@ -201,7 +217,6 @@ const CardPopup: React.FC<CardPopupProps> = ({
               fontSize={fontSize.resultCardContent}
               sx={{
                 padding: 0,
-                paddingX: padding.small,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
                 display: "-webkit-box",
@@ -220,6 +235,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
               onLinks={() => onLinks(content)}
               onDownload={() => onDownload(content)}
               onDetail={() => onDetail(content)}
+              resultCardButtonConfig={{ size: ResultCardButtonSize.SMALL }}
             />
           )}
         </CardContent>

--- a/src/components/map/mapbox/component/MapPopup.tsx
+++ b/src/components/map/mapbox/component/MapPopup.tsx
@@ -33,7 +33,7 @@ interface PopupConfig {
 
 const defaultPopupConfig: PopupConfig = {
   popupWidth: 250,
-  popupHeight: 370,
+  popupHeight: 375,
 };
 
 const renderLoadingBox = ({ popupHeight, popupWidth }: PopupConfig) => (

--- a/src/components/map/mapbox/component/MapPopup.tsx
+++ b/src/components/map/mapbox/component/MapPopup.tsx
@@ -36,13 +36,7 @@ const defaultPopupConfig: PopupConfig = {
   popupHeight: 370,
 };
 
-const renderLoadingBox = ({
-  popupHeight,
-  popupWidth,
-}: {
-  popupHeight: number;
-  popupWidth: number;
-}) => (
+const renderLoadingBox = ({ popupHeight, popupWidth }: PopupConfig) => (
   <Box
     sx={{
       transition: "opacity 0.2s ease-in-out",

--- a/src/components/result/ListResultCard.tsx
+++ b/src/components/result/ListResultCard.tsx
@@ -84,6 +84,8 @@ const ListResultCard: FC<ListResultCardProps> = ({
           <Box maxHeight={isSimplified ? "100%" : "80%"}>
             <CardHeader
               sx={{
+                height: "auto",
+                width: "90%",
                 p: 0,
                 "& .MuiCardHeader-action": {
                   margin: 0,
@@ -93,7 +95,11 @@ const ListResultCard: FC<ListResultCardProps> = ({
                 <Typography
                   onClick={() => onClickDetail(uuid)}
                   color={fontColor.gray.dark}
-                  fontSize={fontSize.resultCardTitle}
+                  fontSize={
+                    isSimplified
+                      ? fontSize.resultCardTitleUnderLaptop
+                      : fontSize.resultCardTitle
+                  }
                   fontWeight={fontWeight.bold}
                   title={title}
                   padding={0}
@@ -101,7 +107,7 @@ const ListResultCard: FC<ListResultCardProps> = ({
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     display: "-webkit-box",
-                    WebkitLineClamp: "2",
+                    WebkitLineClamp: isSimplified ? undefined : "2",
                     WebkitBoxOrient: "vertical",
                     cursor: "pointer",
                     alignItems: "flex-start",
@@ -114,36 +120,50 @@ const ListResultCard: FC<ListResultCardProps> = ({
                 </Typography>
               }
               action={
-                <OrganizationLogo
-                  logo={findIcon()}
-                  sx={{
-                    width: "auto",
-                    maxWidth: "200px",
-                    height: LIST_CARD_TITLE_HEIGHT,
-                    pr: padding.double,
-                    pl: padding.large,
-                  }}
-                />
+                isSimplified ? null : (
+                  <OrganizationLogo
+                    logo={findIcon()}
+                    sx={{
+                      width: "auto",
+                      maxWidth: "200px",
+                      height: LIST_CARD_TITLE_HEIGHT,
+                      pr: padding.double,
+                      pl: padding.large,
+                    }}
+                  />
+                )
               }
             />
             <CardContent
-              sx={{ p: 0, display: "flex", justifyContent: "space-between" }}
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                p: 0,
+                "&:last-child": {
+                  pb: 0,
+                },
+              }}
             >
               <Box sx={{ flex: 1 }}>
                 <Typography
                   arial-label="result-list-card-content"
                   color={fontColor.gray.medium}
-                  fontSize={fontSize.resultCardContent}
+                  fontSize={
+                    isSimplified
+                      ? fontSize.resultCardContentUnderLaptop
+                      : fontSize.resultCardContent
+                  }
                   onClick={() =>
                     isSimplified ? onClickDetail(uuid) : onClickCard(content)
                   }
                   sx={{
-                    padding: 0,
+                    pt: padding.extraSmall,
                     overflow: "hidden",
                     display: "-webkit-box",
                     cursor: "pointer",
-                    WebkitLineClamp:
-                      (isSelectedDataset || showButtons) && !isSimplified
+                    WebkitLineClamp: isSimplified
+                      ? 5
+                      : isSelectedDataset || showButtons
                         ? "4"
                         : "6",
                     WebkitBoxOrient: "vertical",
@@ -183,7 +203,7 @@ const ListResultCard: FC<ListResultCardProps> = ({
               >
                 <ResultCardButtonGroup
                   content={content}
-                  shouldHideText
+                  shouldHideText={isSimplified}
                   onLinks={() => onClickLinks(uuid)}
                   onDownload={
                     onClickDownload

--- a/src/components/result/ResultCardButtonGroup.tsx
+++ b/src/components/result/ResultCardButtonGroup.tsx
@@ -7,7 +7,9 @@ import TaskAltSharpIcon from "@mui/icons-material/TaskAltSharp";
 import DoubleArrowIcon from "@mui/icons-material/DoubleArrow";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
 import { OGCCollection } from "../common/store/OGCCollectionDefinitions";
-import ResultCardButton from "../common/buttons/ResultCardButton";
+import ResultCardButton, {
+  ResultCardButtonConfig,
+} from "../common/buttons/ResultCardButton";
 import { color } from "../../styles/constants";
 
 interface ResultCardButtonGroupProps {
@@ -17,6 +19,7 @@ interface ResultCardButtonGroupProps {
   onLinks?: () => void;
   onDownload?: () => void;
   onDetail?: () => void;
+  resultCardButtonConfig?: ResultCardButtonConfig;
 }
 
 interface ButtonContainerProps {
@@ -42,7 +45,8 @@ const generateLinkText = (linkLength: number) => {
 
 const renderStatusButton = (
   shouldHideText: boolean,
-  content: OGCCollection
+  content: OGCCollection,
+  resultCardButtonConfig?: ResultCardButtonConfig
 ) => {
   const status = content?.getStatus()?.toLowerCase().trim();
   if (status === Status.Completed) {
@@ -51,6 +55,7 @@ const renderStatusButton = (
         startIcon={TaskAltSharpIcon}
         text={"Completed"}
         shouldHideText={shouldHideText}
+        resultCardButtonConfig={resultCardButtonConfig}
       />
     );
   }
@@ -59,7 +64,7 @@ const renderStatusButton = (
       <ResultCardButton
         startIcon={DoubleArrowIcon}
         text={"On Going"}
-        resultCardButtonConfig={{ color: "success" }}
+        resultCardButtonConfig={{ ...resultCardButtonConfig, color: "success" }}
         shouldHideText={shouldHideText}
       />
     );
@@ -69,6 +74,7 @@ const renderStatusButton = (
       startIcon={QuestionMarkIcon}
       text="No Status"
       shouldHideText={shouldHideText}
+      resultCardButtonConfig={resultCardButtonConfig}
     />
   );
 };
@@ -97,6 +103,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
   onLinks = () => {},
   onDownload = undefined,
   onDetail = undefined,
+  resultCardButtonConfig,
 }) => {
   const links = content.getDistributionLinks();
 
@@ -104,7 +111,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
   return (
     <Grid container arial-label="result-list-card-buttons">
       <ButtonContainer isGridView={isGridView}>
-        {renderStatusButton(shouldHideText, content)}
+        {renderStatusButton(shouldHideText, content, resultCardButtonConfig)}
       </ButtonContainer>
       <ButtonContainer isGridView={isGridView}>
         {links && (
@@ -114,6 +121,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
             shouldHideText={shouldHideText}
             onClick={onLinks}
             resultCardButtonConfig={{
+              ...resultCardButtonConfig,
               color: links.length > 0 ? color.blue.dark : color.gray.light,
             }}
             disable={links.length === 0}
@@ -127,6 +135,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
           shouldHideText={shouldHideText}
           disable={onDownload === undefined}
           onClick={onDownload}
+          resultCardButtonConfig={resultCardButtonConfig}
         />
       </ButtonContainer>
       <ButtonContainer isGridView={isGridView}>
@@ -136,6 +145,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
           shouldHideText={shouldHideText}
           disable={onDetail === undefined}
           onClick={onDetail}
+          resultCardButtonConfig={resultCardButtonConfig}
         />
       </ButtonContainer>
     </Grid>

--- a/src/components/result/ResultCardButtonGroup.tsx
+++ b/src/components/result/ResultCardButtonGroup.tsx
@@ -90,6 +90,7 @@ const ButtonContainer: FC<ButtonContainerProps> = ({
     display="flex"
     justifyContent="space-between"
     alignItems="center"
+    height="100%"
     sx={{ ...sx }}
   >
     {children}
@@ -141,7 +142,7 @@ const ResultCardButtonGroup: FC<ResultCardButtonGroupProps> = ({
       <ButtonContainer isGridView={isGridView}>
         <ResultCardButton
           startIcon={InfoIcon}
-          text="More details ..."
+          text="More details"
           shouldHideText={shouldHideText}
           disable={onDetail === undefined}
           onClick={onDetail}

--- a/src/components/result/ResultCards.tsx
+++ b/src/components/result/ResultCards.tsx
@@ -83,7 +83,8 @@ const renderListCards: FC<ResultCardsListType> = ({
               key={index}
               sx={{
                 // Must hardcode, else the box will expand if not enough height
-                height: LIST_CARD_HEIGHT,
+                height: isSimplified ? "auto" : LIST_CARD_HEIGHT,
+                maxHeight: LIST_CARD_HEIGHT,
               }}
             >
               <ListResultCard

--- a/src/styles/constants.ts
+++ b/src/styles/constants.ts
@@ -61,7 +61,9 @@ const fontSize = {
   label: "12px",
   info: "14px",
   resultCardTitle: "14px",
+  resultCardTitleUnderLaptop: "12px",
   resultCardContent: "12px",
+  resultCardContentUnderLaptop: "10px",
 };
 
 const fontFamily = {


### PR DESCRIPTION
1. map hover tip laptop version:  adjust title font size and line clamp to show full title:
![image](https://github.com/user-attachments/assets/37574bf6-3ea4-46c6-9056-0ab03d9f30e5)

2. map popup card tablet version: adjust title font size and line clamp to show full title:
![image](https://github.com/user-attachments/assets/a2879bd1-2b38-4240-a28a-ccf6ba3ed3e3)

3. map popup card mobile version: adjust title font size and line clamp, adjust button size to show full title
![image](https://github.com/user-attachments/assets/d1f8002b-7a9d-4090-bdeb-9c3e899c7cc2)

4. fix bug: click empty space to remove map popup card

5. full list tablet version: remove org logo, flexible height to display full title
![image](https://github.com/user-attachments/assets/a3b99c50-9aea-4443-bd90-55cdba02156c)

6. full list mobile version:  remove org logo, flexible height to display full title
![image](https://github.com/user-attachments/assets/6307c088-5cb7-4b5c-a318-c24f65f5d6a7)

7. for screen size above laptop all have hover-tip to display full tittle, no need to adjust
