### PR TITLE
Bugfix/6582 date range filter optimize test

### DIFF
--- a/src/components/filter/DateRangeFilter.tsx
+++ b/src/components/filter/DateRangeFilter.tsx
@@ -38,7 +38,10 @@ import {
   OGCCollection,
   OGCCollections,
 } from "../common/store/OGCCollectionDefinitions";
-import { fetchResultNoStore } from "../common/store/searchReducer";
+import {
+  fetchResultNoStore,
+  jsonToOGCCollections,
+} from "../common/store/searchReducer";
 import { cqlDefaultFilters } from "../common/cqlFilters";
 import TimeRangeBarChart from "../common/charts/TimeRangeBarChart";
 import PlainDatePicker from "../common/datetime/PlainDatePicker";
@@ -270,7 +273,7 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
         })
       )
         .unwrap()
-        .then((value: OGCCollections) => {
+        .then((value: string) => {
           // Find all id of collection from imosOnly
           dispatch(
             fetchResultNoStore({
@@ -279,12 +282,12 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
             })
           )
             .unwrap()
-            .then((imosOnlyCollection: OGCCollections) => {
-              const ids = imosOnlyCollection.collections.map(
-                (value: OGCCollection) => value.id
-              );
+            .then((imosOnlyCollection: string) => {
+              const ids = jsonToOGCCollections(
+                imosOnlyCollection
+              ).collections.map((value: OGCCollection) => value.id);
               setImosDataIds(ids);
-              setTotalDataset(value);
+              setTotalDataset(jsonToOGCCollections(value));
             });
         });
     }, [dispatch]);

--- a/src/components/filter/DateRangeFilter.tsx
+++ b/src/components/filter/DateRangeFilter.tsx
@@ -192,7 +192,7 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
 
     const handleMinDateChange = useCallback(
       (newMinDate: Dayjs | null) => {
-        // For min date we always set to end of day time 00:00:00
+        // For min date we always set to start of day time 00:00:00
         const localMinDate = newMinDate
           ?.set("hour", 0)
           .set("minute", 0)

--- a/src/components/filter/DateRangeFilter.tsx
+++ b/src/components/filter/DateRangeFilter.tsx
@@ -192,10 +192,16 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
 
     const handleMinDateChange = useCallback(
       (newMinDate: Dayjs | null) => {
-        if (newMinDate && dateToValue(newMinDate) < dateToValue(maxDate)) {
-          const newStart = dateToValue(newMinDate);
+        // For min date we always set to end of day time 00:00:00
+        const localMinDate = newMinDate
+          ?.set("hour", 0)
+          .set("minute", 0)
+          .set("second", 0);
+
+        if (localMinDate && dateToValue(localMinDate) < dateToValue(maxDate)) {
+          const newStart = dateToValue(localMinDate);
           setValue([newStart, value[1]]);
-          setSelectedOption(determineSelectedOption(newMinDate, maxDate));
+          setSelectedOption(determineSelectedOption(localMinDate, maxDate));
           dispatch(
             updateDateTimeFilterRange({
               start: newStart,
@@ -215,10 +221,17 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
 
     const handleMaxDateChange = useCallback(
       (newMaxDate: Dayjs | null) => {
-        if (newMaxDate && dateToValue(newMaxDate) > dateToValue(minDate)) {
-          const newEnd = dateToValue(newMaxDate);
+        // For max date we always set to end of day time to 23:59:59
+        const localMaxDate = newMaxDate
+          ?.set("hour", 23)
+          .set("minute", 59)
+          .set("second", 59)
+          .set("millisecond", 0);
+
+        if (localMaxDate && dateToValue(localMaxDate) > dateToValue(minDate)) {
+          const newEnd = dateToValue(localMaxDate);
           setValue([value[0], newEnd]);
-          setSelectedOption(determineSelectedOption(minDate, newMaxDate));
+          setSelectedOption(determineSelectedOption(minDate, localMaxDate));
           dispatch(
             updateDateTimeFilterRange({
               start: dateTimeFilterRange?.start,
@@ -415,7 +428,7 @@ const DateRangeFilter: FC<DateRangeFilterProps> = memo(
                       fontWeight={fontWeight.bold}
                       color={fontColor.blue.dark}
                     >
-                      End&nbsp;&nbsp;&nbsp;Date
+                      End&nbsp;Date
                     </Typography>
                     <PlainDatePicker
                       views={["year", "month", "day"]}

--- a/src/components/filter/__test__/DataRangeFilter.test.tsx
+++ b/src/components/filter/__test__/DataRangeFilter.test.tsx
@@ -13,6 +13,9 @@ import { dateToValue } from "../../../utils/DateUtils";
 import axios from "axios";
 import { responseIdTemporal, responseIdProvider } from "./canned";
 
+const initialMinDate: Dayjs = dayjs(dateDefault.min);
+const initialMaxDate: Dayjs = dayjs(dateDefault.max);
+
 // Mock Redux store
 const mockInitialState = {
   paramReducer: {
@@ -123,36 +126,43 @@ describe("DateRangeFilter", () => {
     );
   });
 
-  it.skip("updates date range when start date is changed via date picker", async () => {
+  it.skip("updates date range when start date is changed via date picker", () => {
     renderComponent();
     const user = userEvent.setup();
+    const minDate = initialMinDate.format(dateDefault.DISPLAY_FORMAT);
 
-    const startDatePicker = screen.getByLabelText(/start date/i);
-    const newDate = dayjs("2020-01-01");
-    await user.type(startDatePicker, newDate.format("MM/DD/YYYY"));
+    return waitFor(() => screen.findByText(minDate)).then(() => {
+      const startDatePicker = screen.getByText(minDate);
+      const newDate = dayjs("2020-01-01");
+      user.type(startDatePicker, newDate.format(dateDefault.DISPLAY_FORMAT));
 
-    expect(store.dispatch).toHaveBeenCalledWith(
-      updateDateTimeFilterRange({
-        start: dateToValue(newDate),
-        end: mockInitialState.paramReducer.dateTimeFilterRange.end,
-      })
-    );
+      return waitFor(() =>
+        expect(store.dispatch).toHaveBeenCalledWith(
+          updateDateTimeFilterRange({
+            start: dateToValue(newDate),
+            end: mockInitialState.paramReducer.dateTimeFilterRange.end,
+          })
+        )
+      );
+    });
   });
 
-  it.skip("updates date range when end date is changed via date picker", async () => {
+  it.skip("updates date range when end date is changed via date picker", () => {
     renderComponent();
     const user = userEvent.setup();
 
-    const endDatePicker = screen.getByLabelText(/end date/i);
-    const newDate = dayjs("2025-01-01");
-    await user.type(endDatePicker, newDate.format("MM/DD/YYYY"));
+    return waitFor(() => screen.findAllByLabelText(/end date/i)).then(() => {
+      const endDatePicker = screen.getByLabelText(/end date/i);
+      const newDate = dayjs("2025-01-01");
+      user.type(endDatePicker, newDate.format("MM/DD/YYYY"));
 
-    expect(store.dispatch).toHaveBeenCalledWith(
-      updateDateTimeFilterRange({
-        start: mockInitialState.paramReducer.dateTimeFilterRange.start,
-        end: dateToValue(newDate),
-      })
-    );
+      expect(store.dispatch).toHaveBeenCalledWith(
+        updateDateTimeFilterRange({
+          start: mockInitialState.paramReducer.dateTimeFilterRange.start,
+          end: dateToValue(newDate),
+        })
+      );
+    });
   });
 
   it("resets date range when clear button is clicked", () => {
@@ -177,19 +187,21 @@ describe("DateRangeFilter", () => {
     return waitFor(() => expect(handleClosePopup).toHaveBeenCalled());
   });
 
-  it.skip("updates date range when slider is moved", async () => {
+  it.skip("updates date range when slider is moved", () => {
     renderComponent();
     const user = userEvent.setup();
 
-    const slider = screen.getByRole("slider");
-    await user.type(slider, "{arrowright}"); // Simulate slider movement
+    return waitFor(() => screen.findByRole("slider")).then(() => {
+      const slider = screen.getByRole("slider");
+      user.type(slider, "{arrowright}"); // Simulate slider movement
 
-    expect(store.dispatch).toHaveBeenCalledWith(
-      updateDateTimeFilterRange({
-        start: expect.any(Number),
-        end: expect.any(Number),
-      })
-    );
+      expect(store.dispatch).toHaveBeenCalledWith(
+        updateDateTimeFilterRange({
+          start: expect.any(Number),
+          end: expect.any(Number),
+        })
+      );
+    });
   });
 
   it.skip("renders TimeRangeBarChart with correct props", async () => {

--- a/src/components/filter/__test__/DataRangeFilter.test.tsx
+++ b/src/components/filter/__test__/DataRangeFilter.test.tsx
@@ -126,17 +126,20 @@ describe("DateRangeFilter", () => {
     );
   });
 
-  it.skip("updates date range when start date is changed via date picker", () => {
+  it("updates date range when start date is changed via date picker", () => {
     renderComponent();
     const user = userEvent.setup();
     const minDate = initialMinDate.format(dateDefault.DISPLAY_FORMAT);
 
-    return waitFor(() => screen.findByText(minDate)).then(() => {
-      const startDatePicker = screen.getByText(minDate);
-      const newDate = dayjs("2020-01-01");
-      user.type(startDatePicker, newDate.format(dateDefault.DISPLAY_FORMAT));
+    return waitFor(() => screen.findByDisplayValue(minDate)).then(() => {
+      const startDatePicker = screen.getByDisplayValue(minDate);
+      user.click(startDatePicker);
 
-      return waitFor(() =>
+      const newDate = dayjs("2020-01-01");
+      const newStringDate = newDate.format(dateDefault.DISPLAY_FORMAT);
+      user.type(startDatePicker, newStringDate);
+
+      return waitFor(() => screen.findByDisplayValue(newStringDate)).then(() =>
         expect(store.dispatch).toHaveBeenCalledWith(
           updateDateTimeFilterRange({
             start: dateToValue(newDate),
@@ -147,20 +150,32 @@ describe("DateRangeFilter", () => {
     });
   });
 
-  it.skip("updates date range when end date is changed via date picker", () => {
+  it("updates date range when end date is changed via date picker", () => {
     renderComponent();
     const user = userEvent.setup();
+    const maxDate = initialMaxDate.format(dateDefault.DISPLAY_FORMAT);
 
-    return waitFor(() => screen.findAllByLabelText(/end date/i)).then(() => {
-      const endDatePicker = screen.getByLabelText(/end date/i);
+    return waitFor(() => screen.findByDisplayValue(maxDate)).then(() => {
+      const endDatePicker = screen.getByDisplayValue(maxDate);
+      user.click(endDatePicker);
+
       const newDate = dayjs("2025-01-01");
-      user.type(endDatePicker, newDate.format("MM/DD/YYYY"));
+      const newStringDate = newDate.format(dateDefault.DISPLAY_FORMAT);
+      user.type(endDatePicker, newStringDate);
 
-      expect(store.dispatch).toHaveBeenCalledWith(
-        updateDateTimeFilterRange({
-          start: mockInitialState.paramReducer.dateTimeFilterRange.start,
-          end: dateToValue(newDate),
-        })
+      return waitFor(() => screen.findByDisplayValue(newStringDate)).then(() =>
+        expect(store.dispatch).toHaveBeenCalledWith(
+          updateDateTimeFilterRange({
+            start: mockInitialState.paramReducer.dateTimeFilterRange.start,
+            end: dateToValue(
+              newDate
+                .set("hour", 23)
+                .set("minute", 59)
+                .set("second", 59)
+                .set("millisecond", 0)
+            ),
+          })
+        )
       );
     });
   });

--- a/src/components/map/mapbox/component/SpatialExtents.tsx
+++ b/src/components/map/mapbox/component/SpatialExtents.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback, useContext, useEffect } from "react";
 import MapContext from "../MapContext";
 import {
   fetchResultNoStore,
+  jsonToOGCCollections,
   SearchParameters,
 } from "../../../common/store/searchReducer";
 import { MapLayerMouseEvent } from "mapbox-gl";
@@ -46,7 +47,7 @@ const SpatialExtents: FC<SpatialExtentsProps> = ({
 
       return dispatch(fetchResultNoStore(param))
         .unwrap()
-        .then((value: OGCCollections) => value.collections[0])
+        .then((value: string) => jsonToOGCCollections(value).collections[0])
         .catch((error: any) => {
           console.error("Error fetching collection data:", error);
           // TODO: handle error in ErrorBoundary

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -14,6 +14,7 @@ import {
   fetchResultByUuidNoStore,
   fetchResultNoStore,
   fetchResultWithStore,
+  jsonToOGCCollections,
 } from "../../components/common/store/searchReducer";
 import {
   formatToUrlParam,
@@ -129,7 +130,8 @@ const SearchPage = () => {
     const paramNonPaged = createSearchParamFrom(componentParam, {
       pagesize: DEFAULT_SEARCH_MAP_SIZE,
     });
-    const collections = await dispatch(
+
+    dispatch(
       // add param "sortby: id" for fetchResultNoStore to ensure data source for map is always sorted
       // and ordered by uuid to avoid affecting cluster calculation
       fetchResultNoStore({
@@ -137,8 +139,11 @@ const SearchPage = () => {
         properties: "id,centroid",
         sortby: "id",
       })
-    ).unwrap();
-    setLayers(collections.collections);
+    )
+      .unwrap()
+      .then((collections: string) => {
+        setLayers(jsonToOGCCollections(collections).collections);
+      });
   }, [dispatch]);
 
   const doSearch = useCallback(


### PR DESCRIPTION
I spot an error related to the serialization of of object in Redux during test, it may not show in normal run but that signal an potential issue. So I fix it in the PR too.

Basically Redux expect action.payload to be something that can be serializable, for example string. However before the change the payload is OGCCollections with method that cannot be serializable, therefore warning/error appears in test run for data range filter.

I changed the function to return string and move the conversion to the reducer part. For the no store method, caller is expect to call the conversion after obtain the string.