### PR TITLE
Feature/6431 less sticky centroid

### DIFF
--- a/src/components/map/mapbox/layers/ClusterLayer.tsx
+++ b/src/components/map/mapbox/layers/ClusterLayer.tsx
@@ -103,6 +103,7 @@ const ClusterLayer: FC<ClusterLayerProps> = ({
   selectedUuids,
   onClickMapPoint: onDatasetSelected,
   tabNavigation,
+  preferCurrentCentroid = true,
   clusterLayerConfig,
 }: ClusterLayerProps) => {
   const { map } = useContext(MapContext);
@@ -270,13 +271,18 @@ const ClusterLayer: FC<ClusterLayerProps> = ({
   const updateSource = useCallback(() => {
     if (map?.getSource(clusterSourceId)) {
       setLastVisiblePoint((p) => {
-        const newData = findSuitableVisiblePoint(featureCollection, map, p);
+        const newData = findSuitableVisiblePoint(
+          featureCollection,
+          map,
+          p,
+          preferCurrentCentroid
+        );
 
         (map?.getSource(clusterSourceId) as GeoJSONSource).setData(newData);
         return newData;
       });
     }
-  }, [map, clusterSourceId, featureCollection]);
+  }, [map, clusterSourceId, featureCollection, preferCurrentCentroid]);
 
   useEffect(() => {
     updateSource();

--- a/src/components/map/mapbox/layers/HeatmapLayer.tsx
+++ b/src/components/map/mapbox/layers/HeatmapLayer.tsx
@@ -111,6 +111,7 @@ const HeatmapLayer: FC<HeatmapLayerProps> = ({
   selectedUuids,
   onClickMapPoint: onDatasetSelected,
   tabNavigation,
+  preferCurrentCentroid = true,
   heatmapLayerConfig,
 }: HeatmapLayerProps) => {
   const { map } = useContext(MapContext);
@@ -309,7 +310,12 @@ const HeatmapLayer: FC<HeatmapLayerProps> = ({
 
   const updateSource = useCallback(() => {
     setLastVisiblePoint((p) => {
-      const newData = findSuitableVisiblePoint(featureCollection, map, p);
+      const newData = findSuitableVisiblePoint(
+        featureCollection,
+        map,
+        p,
+        preferCurrentCentroid
+      );
       if (map?.getSource(heatmapSourceId)) {
         (map?.getSource(heatmapSourceId) as GeoJSONSource).setData(newData);
       }
@@ -318,7 +324,13 @@ const HeatmapLayer: FC<HeatmapLayerProps> = ({
       }
       return newData;
     });
-  }, [featureCollection, map, heatmapSourceId, clusterSourceId]);
+  }, [
+    featureCollection,
+    map,
+    heatmapSourceId,
+    clusterSourceId,
+    preferCurrentCentroid,
+  ]);
 
   useEffect(() => {
     updateSource();

--- a/src/components/map/mapbox/layers/Layers.tsx
+++ b/src/components/map/mapbox/layers/Layers.tsx
@@ -14,6 +14,10 @@ export interface LayerBasicType {
   // dataset that user selected from result list or map
   selectedUuids?: string[];
   tabNavigation?: TabNavigation;
+  // True to make the centroid more sticky, so that centroid will stay in current
+  // location even map drag. Centroid only move when it is absolute necessary like
+  // outside of viewport.
+  preferCurrentCentroid?: boolean;
 }
 // Use to create static layer on map, you need to add menu item to select those layers,
 // refer to map section
@@ -75,7 +79,8 @@ const isFeatureVisible = (
 const findSuitableVisiblePoint = (
   featureCollection: FeatureCollection<Point>,
   map: mapboxgl.Map | null | undefined = undefined,
-  currentVisibleCollection: FeatureCollection<Point> | undefined = undefined
+  currentVisibleCollection: FeatureCollection<Point> | undefined = undefined,
+  preferCurrentCentroid: boolean = true
 ): FeatureCollection<Point> => {
   const featureCollections: FeatureCollection<Point> = {
     type: "FeatureCollection",
@@ -117,8 +122,10 @@ const findSuitableVisiblePoint = (
     if (!uniqueFeatures.has(id)) {
       // Is this point visible in previous search? If yes then we prefer this
       // point over the most center point, this helps to reduce point change
-      // for the same visible record
-      const f = currentVisible?.find((o) => o.properties?.uuid === id);
+      // for the same visible record if preferCurrentCentroid is true
+      const f = preferCurrentCentroid
+        ? currentVisible?.find((o) => o.properties?.uuid === id)
+        : feature;
       uniqueFeatures.set(feature.properties?.uuid, f ? f : feature);
     }
   }

--- a/src/components/map/mapbox/layers/UnclusterLayer.tsx
+++ b/src/components/map/mapbox/layers/UnclusterLayer.tsx
@@ -54,6 +54,7 @@ const UnclusterLayer: FC<UnclusterLayerProps> = ({
   selectedUuids,
   onClickMapPoint: onDatasetSelected,
   tabNavigation,
+  preferCurrentCentroid = true,
   unclusterLayerConfig,
 }: UnclusterLayerProps) => {
   const { map } = useContext(MapContext);
@@ -135,13 +136,18 @@ const UnclusterLayer: FC<UnclusterLayerProps> = ({
   const updateSource = useCallback(() => {
     if (map?.getSource(unclusterSourceId)) {
       setLastVisiblePoint((p) => {
-        const newData = findSuitableVisiblePoint(featureCollection, map, p);
+        const newData = findSuitableVisiblePoint(
+          featureCollection,
+          map,
+          p,
+          preferCurrentCentroid
+        );
 
         (map?.getSource(unclusterSourceId) as GeoJSONSource).setData(newData);
         return newData;
       });
     }
-  }, [map, unclusterSourceId, featureCollection]);
+  }, [map, unclusterSourceId, featureCollection, preferCurrentCentroid]);
 
   useEffect(() => {
     updateSource();

--- a/src/pages/search-page/subpages/MapSection.tsx
+++ b/src/pages/search-page/subpages/MapSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { MapboxEvent as MapEvent } from "mapbox-gl";
 import { Paper, SxProps, Theme } from "@mui/material";
 import Map, { MapBasicType } from "../../../components/map/mapbox/Map";
@@ -31,6 +31,10 @@ import BookmarkListMenu, {
   BookmarkListMenuBasicType,
 } from "../../../components/map/mapbox/controls/menu/BookmarkListMenu";
 import useBreakpoint from "../../../hooks/useBreakpoint";
+import { ParameterState } from "../../../components/common/store/componentParamReducer";
+import store, {
+  getComponentState,
+} from "../../../components/common/store/store";
 
 interface MapSectionProps
   extends Partial<MapBasicType>,
@@ -62,6 +66,10 @@ const createPresentationLayers = (
   tabNavigation: TabNavigation,
   onClickMapPoint: ((uuids: Array<string>) => void) | undefined
 ) => {
+  // If user set polygon search area, that means user have strong preference
+  // and expect result within the area
+  const componentParam: ParameterState = getComponentState(store.getState());
+
   switch (id) {
     case LayerName.Heatmap:
       return (
@@ -70,6 +78,7 @@ const createPresentationLayers = (
           selectedUuids={selectedUuids}
           onClickMapPoint={onClickMapPoint}
           tabNavigation={tabNavigation}
+          preferCurrentCentroid={componentParam.polygon === undefined}
         />
       );
 
@@ -80,6 +89,7 @@ const createPresentationLayers = (
           selectedUuids={selectedUuids}
           onClickMapPoint={onClickMapPoint}
           tabNavigation={tabNavigation}
+          preferCurrentCentroid={componentParam.polygon === undefined}
         />
       );
 
@@ -90,6 +100,7 @@ const createPresentationLayers = (
           selectedUuids={selectedUuids}
           onClickMapPoint={onClickMapPoint}
           tabNavigation={tabNavigation}
+          preferCurrentCentroid={componentParam.polygon === undefined}
         />
       );
   }


### PR DESCRIPTION
If user search by area, that is INTERSECTS(polygon......) then we set strong preference on the centroid from ogcapi, ignore centroid already on the map for the same UUID search result. This makes sure the centroid is within the boundary of the polygon