### PR TITLE
Check if thumnbnail is a broken url.

### DIFF
--- a/src/components/result/GridResultCard.tsx
+++ b/src/components/result/GridResultCard.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, SyntheticEvent, useState } from "react";
 import {
   Box,
   Card,
@@ -21,6 +21,7 @@ import OrganizationLogo from "../logo/OrganizationLogo";
 import ResultCardButtonGroup from "./ResultCardButtonGroup";
 import { ResultCardBasicType } from "./ResultCards";
 import BookmarkButton from "../bookmark/BookmarkButton";
+import default_thumbnail from "@/assets/images/default-thumbnail.png";
 
 interface GridResultCardProps extends ResultCardBasicType {}
 
@@ -91,6 +92,10 @@ const GridResultCard: FC<GridResultCardProps> = ({
               objectFit: "fill",
               width: "100%",
               height: "auto",
+            }}
+            onError={(e: SyntheticEvent<HTMLImageElement, Event>) => {
+              e.preventDefault();
+              e.currentTarget.src = default_thumbnail;
             }}
           />
         </Box>

--- a/src/components/result/ListResultCard.tsx
+++ b/src/components/result/ListResultCard.tsx
@@ -4,7 +4,6 @@ import {
   CardActions,
   CardContent,
   CardHeader,
-  Stack,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -18,7 +17,7 @@ import {
   gap,
   padding,
 } from "../../styles/constants";
-import { FC, useState } from "react";
+import { FC, SyntheticEvent, useState } from "react";
 import OrganizationLogo from "../logo/OrganizationLogo";
 import ResultCardButtonGroup from "./ResultCardButtonGroup";
 import { ResultCardBasicType } from "./ResultCards";
@@ -188,6 +187,18 @@ const ListResultCard: FC<ListResultCardProps> = ({
                       width: "100%",
                       height: "100%",
                       objectFit: "contain",
+                    }}
+                    onError={(e: SyntheticEvent<HTMLImageElement, Event>) => {
+                      e.preventDefault();
+                      // This is a special case where the src is a valid url,
+                      // but the url is not reachable, then we fallback to use the
+                      // default thumbnail, and in this case like above we should hide
+                      // the thumbnail
+                      const parent = e.currentTarget.parentElement;
+                      if (parent) {
+                        e.currentTarget.src = default_thumbnail;
+                        parent.style.display = "none";
+                      }
                     }}
                   />
                 </Box>


### PR DESCRIPTION
In case the url is valid from metadata, but it is not reachable due to not maintain it well, we hide it.