### PR TITLE
Allow call cancel to avoid flip with unmount

### DIFF
--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -90,7 +90,10 @@ const initialState: ObjectValue = {
 /**
  Define search functions
  */
-const searchResult = async (param: SearchParameters, thunkApi: any) => {
+const searchResult = async (
+  param: SearchParameters & { signal?: AbortSignal },
+  thunkApi: any
+) => {
   const p: OGCSearchParameters = {
     properties:
       param.properties !== undefined
@@ -116,6 +119,7 @@ const searchResult = async (param: SearchParameters, thunkApi: any) => {
     .get<string>("/api/v1/ogc/collections", {
       params: p,
       timeout: TIMEOUT,
+      signal: param.signal || thunkApi.signal,
     })
     .then((response) => response.data)
     .catch((error: Error | AxiosError | ErrorResponse) => {

--- a/src/components/map/mapbox/constants.ts
+++ b/src/components/map/mapbox/constants.ts
@@ -1,6 +1,6 @@
 export const MapDefaultConfig = {
   // Magic number, try and error by experience
-  DEBOUNCE_BEFORE_EVENT_FIRE: 700,
+  DEBOUNCE_BEFORE_EVENT_FIRE: 1000,
   ZOOM: 3.5,
   ZOOM_TABLET: 3,
   ZOOM_MOBILE: 2,

--- a/src/components/map/mapbox/layers/GeoServerTileLayer.tsx
+++ b/src/components/map/mapbox/layers/GeoServerTileLayer.tsx
@@ -127,7 +127,7 @@ const GeoServerTileLayer: FC<GeoServerTileLayerProps> = ({
     if (map === null || map === undefined) return;
 
     const createSource = () => {
-      if (isWMSAvailable && !map?.isSourceLoaded(sourceLayerId)) {
+      if (isWMSAvailable) {
         // Add the WMS source following Mapbox's example
         if (!map?.getSource(sourceLayerId)) {
           map?.addSource(sourceLayerId, {
@@ -191,11 +191,6 @@ const GeoServerTileLayer: FC<GeoServerTileLayerProps> = ({
       if (map?.isStyleLoaded()) {
         if (titleLayerId && map?.getLayer(titleLayerId)) {
           map?.removeLayer(titleLayerId);
-        }
-      }
-      if (map?.isSourceLoaded(sourceLayerId)) {
-        if (sourceLayerId && map?.getSource(sourceLayerId)) {
-          map?.removeSource(sourceLayerId);
         }
       }
     };

--- a/src/pages/detail-page/subpages/side-cards/SideCardContainer.tsx
+++ b/src/pages/detail-page/subpages/side-cards/SideCardContainer.tsx
@@ -45,7 +45,7 @@ const SideCardContainer: FC<SideCardContainerProps> = ({
           },
         }}
       />
-      <Divider sx={{ width: "100%" }} />
+      <Divider sx={{ width: "100%" }} component={"div"} />
       {children}
     </Card>
   );

--- a/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
@@ -61,8 +61,8 @@ const DataAccessPanel: FC<DataAccessPanelProps> = ({ mode, type }) => {
                 {!item || item.length === 0 ? (
                   <NaList title={title ? title : ""} />
                 ) : (
-                  item.map((link: ILink) => (
-                    <LinkCard key={link.href} link={link} icon={false} />
+                  item.map((link: ILink, index: number) => (
+                    <LinkCard key={`ch-${index}`} link={link} icon={false} />
                   ))
                 )}
               </Typography>

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { LngLatBounds, MapboxEvent as MapEvent } from "mapbox-gl";
 import { Box } from "@mui/material";
@@ -86,6 +86,9 @@ const SearchPage = () => {
         : MapDefaultConfig.ZOOM_TABLET
       : undefined
   );
+  // Add these refs outside the functions, e.g., in the component body
+  const listSearchAbortRef = useRef<AbortController | null>(null);
+  const mapSearchAbortRef = useRef<AbortController | null>(null);
   const urlParamState: ParameterState | undefined = useMemo(() => {
     // The first char is ? in the search string, so we need to remove it.
     const param = location?.search?.substring(1);
@@ -95,50 +98,85 @@ const SearchPage = () => {
     return undefined;
   }, [location?.search]);
 
-  const doMapSearch = useCallback(async () => {
-    const componentParam: ParameterState = getComponentState(store.getState());
-    // Use a different parameter so that it returns id and bbox only and do not store the values,
-    // we cannot add page because we want to show all record on map
-    // and by default we will include record without spatial extents so that BBOX
-    // will not exclude record without spatial extents however for map search
-    // it is ok to exclude it because it isn't show on map anyway
-    const paramNonPaged: SearchParameters = createSearchParamFrom(
-      componentParam,
-      {
-        pagesize: DEFAULT_SEARCH_MAP_SIZE,
+  const doMapSearch = useCallback(
+    async (needNavigate: boolean = false) => {
+      const componentParam: ParameterState = getComponentState(
+        store.getState()
+      );
+      // Use a different parameter so that it returns id and bbox only and do not store the values,
+      // we cannot add page because we want to show all record on map
+      // and by default we will include record without spatial extents so that BBOX
+      // will not exclude record without spatial extents however for map search
+      // it is ok to exclude it because it isn't show on map anyway
+      // Abort any ongoing search if exists
+      if (mapSearchAbortRef.current) {
+        mapSearchAbortRef.current.abort();
       }
-    );
-    dispatch(
-      // add param "sortby: id" for fetchResultNoStore to ensure data source for map is always sorted
-      // and ordered by uuid to avoid affecting cluster calculation
-      fetchResultNoStore({
-        ...paramNonPaged,
-        properties: "id,centroid",
-        sortby: "id",
-      })
-    )
-      .unwrap()
-      .then((collections: string) => {
-        // This check is need due to user can move the map around when the search
-        // is still in progress, the store have the latest map bbox so we can check
-        // if the constant we store matches the bbox, if not then we know map
-        // moved and results isn't valid
-        const current = getComponentState(store.getState())?.bbox;
-        if (
-          componentParam.bbox !== undefined &&
-          current !== undefined &&
-          booleanEqual(componentParam.bbox, current)
-        ) {
-          setLayers(jsonToOGCCollections(collections).collections);
-        }
-      });
-  }, [dispatch]);
+      const controller = new AbortController();
+      mapSearchAbortRef.current = controller;
 
-  const doSearch = useCallback(
+      const paramNonPaged: SearchParameters = createSearchParamFrom(
+        componentParam,
+        {
+          pagesize: DEFAULT_SEARCH_MAP_SIZE,
+        }
+      );
+      dispatch(
+        // add param "sortby: id" for fetchResultNoStore to ensure data source for map is always sorted
+        // and ordered by uuid to avoid affecting cluster calculation
+        fetchResultNoStore({
+          ...paramNonPaged,
+          properties: "id,centroid",
+          sortby: "id",
+          signal: controller.signal,
+        } as SearchParameters & { signal: AbortSignal })
+      )
+        .unwrap()
+        .then((collections: string) => {
+          // This check is need due to user can move the map around when the search
+          // is still in progress, the store have the latest map bbox so we can check
+          // if the constant we store matches the bbox, if not then we know map
+          // moved and results isn't valid
+          const current = getComponentState(store.getState())?.bbox;
+          if (
+            componentParam.bbox !== undefined &&
+            current !== undefined &&
+            booleanEqual(componentParam.bbox, current)
+          ) {
+            setLayers(jsonToOGCCollections(collections).collections);
+          }
+        })
+        .then(() => {
+          if (needNavigate) {
+            navigate(
+              pageDefault.search + "?" + formatToUrlParam(componentParam),
+              {
+                state: {
+                  fromNavigate: true,
+                  requireSearch: false,
+                  referer: pageReferer.SEARCH_PAGE_REFERER,
+                },
+              }
+            );
+          }
+        })
+        .catch((error) => {
+          // console.log("doSearchMap signal abort");
+        });
+    },
+    [dispatch, navigate]
+  );
+
+  const doListSearch = useCallback(
     (needNavigate: boolean = false) => {
       const componentParam: ParameterState = getComponentState(
         store.getState()
       );
+
+      if (listSearchAbortRef.current) {
+        listSearchAbortRef.current.abort();
+      }
+      listSearchAbortRef.current = new AbortController();
 
       // Use standard param to get fields you need, record is stored in redux,
       // set page so that it returns fewer records
@@ -146,23 +184,15 @@ const SearchPage = () => {
         pagesize: DEFAULT_SEARCH_PAGE_SIZE,
       });
 
-      dispatch(fetchResultWithStore(paramPaged));
-      doMapSearch().then(() => {
-        if (needNavigate) {
-          navigate(
-            pageDefault.search + "?" + formatToUrlParam(componentParam),
-            {
-              state: {
-                fromNavigate: true,
-                requireSearch: false,
-                referer: pageReferer.SEARCH_PAGE_REFERER,
-              },
-            }
-          );
-        }
-      });
+      const paramPagedWithSignal = {
+        ...paramPaged,
+        signal: listSearchAbortRef.current.signal,
+      };
+
+      dispatch(fetchResultWithStore(paramPagedWithSignal));
+      doMapSearch(needNavigate)?.finally(() => {});
     },
-    [dispatch, doMapSearch, navigate]
+    [dispatch, doMapSearch]
   );
 
   // The result will be changed based on the zoomed area, that is only
@@ -184,50 +214,17 @@ const SearchPage = () => {
         // due to some redraw, so in here we check if the polygon really
         // changed, if not then there is no need to do anything
         if (componentParam.bbox && !booleanEqual(componentParam.bbox, bbox)) {
-          setBbox(bounds);
-          setZoom(event.target.getZoom());
+          // These two lines cause flick on map move, why we need that two line?
+          //setBbox(bounds);
+          //setZoom(event.target.getZoom());
           dispatch(updateFilterBBox(bbox));
           dispatch(updateZoom(event.target.getZoom()));
-          doSearch(true);
+          doListSearch(true);
         }
       }
     },
-    [dispatch, doSearch]
+    [dispatch, doListSearch]
   );
-
-  const handleNavigation = useCallback(() => {
-    const reduxContents = getSearchQueryResult(store.getState());
-    if (
-      location.state?.referer === pageReferer.SEARCH_PAGE_REFERER &&
-      location.state?.requireSearch === false
-    ) {
-      // If the referer is SEARCH_PAGE_REFERER, it means the user is interacting with the search page
-      // Meanwhile if the state requireSearch is false, it means the user is not required to do a search. This happens when user just change the layout
-      // However the referer = SEARCH_PAGE_REFERER and requireSearch = false will be persist but redux will be cleared when user refresh the page, so we need to do a full search
-      // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or no search
-      if (reduxContents.result.total > 0) {
-        return;
-      } else {
-        doSearch();
-      }
-    } else if (
-      // If user navigate from DetailPage, as the redux store has results content already we just need to do a map search
-      // However when user refresh the page, the redux will be cleared, we need to do a full search
-      // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or only map search
-      location.state?.referer === pageReferer.DETAIL_PAGE_REFERER &&
-      location.state?.requireSearch === false
-    ) {
-      if (reduxContents.result.total > 0) {
-        doMapSearch().finally();
-      } else {
-        doSearch();
-      }
-    } else {
-      // In the other cases we need to do a full search
-      // This including (but not limit): user paste the url directly, navigate from landing page, change sort ...
-      doSearch();
-    }
-  }, [location, doSearch, doMapSearch]);
 
   // Value true meaning full map. So if true set the selected layout as full-map
   // Else set the selected layout as the last layout remembered (stored in currentLayout)
@@ -289,9 +286,9 @@ const SearchPage = () => {
           break;
       }
 
-      doSearch(true);
+      return doListSearch(true);
     },
-    [dispatch, doSearch]
+    [dispatch, doListSearch]
   );
 
   const onChangeLayout = useCallback(
@@ -386,7 +383,56 @@ const SearchPage = () => {
   // which is ok.
   // TODO: Optimize call if possible, this happens when navigate from page
   // to this page.
-  useEffect(() => handleNavigation(), [handleNavigation]);
+  useEffect(() => {
+    const handleNavigation = () => {
+      const reduxContents = getSearchQueryResult(store.getState());
+      if (
+        location.state?.referer === pageReferer.SEARCH_PAGE_REFERER &&
+        location.state?.requireSearch === false
+      ) {
+        // If the referer is SEARCH_PAGE_REFERER, it means the user is interacting with the search page
+        // Meanwhile if the state requireSearch is false, it means the user is not required to do a search. This happens when user just change the layout
+        // However the referer = SEARCH_PAGE_REFERER and requireSearch = false will be persist but redux will be cleared when user refresh the page, so we need to do a full search
+        // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or no search
+        if (reduxContents.result.total > 0) {
+          return;
+        } else {
+          doListSearch();
+        }
+      } else if (
+        // If user navigate from DetailPage, as the redux store has results content already we just need to do a map search
+        // However when user refresh the page, the redux will be cleared, we need to do a full search
+        // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or only map search
+        location.state?.referer === pageReferer.DETAIL_PAGE_REFERER &&
+        location.state?.requireSearch === false
+      ) {
+        if (reduxContents.result.total > 0) {
+          doMapSearch();
+        } else {
+          doListSearch();
+        }
+      } else {
+        // In the other cases we need to do a full search
+        // This including (but not limit): user paste the url directly, navigate from landing page, change sort ...
+        doListSearch();
+      }
+    };
+
+    handleNavigation();
+
+    return () => {
+      // If page unmounted, cancel any running search
+      mapSearchAbortRef.current?.abort();
+      mapSearchAbortRef.current = null;
+      listSearchAbortRef.current?.abort();
+      listSearchAbortRef.current = null;
+    };
+  }, [
+    doListSearch,
+    doMapSearch,
+    location.state?.referer,
+    location.state?.requireSearch,
+  ]);
 
   useEffect(() => {
     const bookmarkSelected = (event: BookmarkEvent) => {


### PR DESCRIPTION
Sometime the map still flick, when you move the map around during search and it sometime recenter, this is due to the call to doMapSearch with  needNavigate. 

Since this is something existing , it is better resolve it with different ticket