### PR TITLE
:bug: fix python notebook list

### DIFF
--- a/src/components/list/CodeTutorialsList.tsx
+++ b/src/components/list/CodeTutorialsList.tsx
@@ -1,0 +1,42 @@
+// CodeTutorialsList is a List component that displays a list of python notebook links
+import React from "react";
+import ExpandableList from "./ExpandableList";
+import ItemBaseGrid from "./listItem/ItemBaseGrid";
+import { ILink } from "../common/store/OGCCollectionDefinitions";
+import LinkCard from "./listItem/subitem/LinkCard";
+
+interface CodeTutorialsListProps {
+  pythonNotebookLinks?: ILink[];
+  title?: string;
+  selected?: boolean;
+}
+
+const INFO_TIP_CONTENT = {
+  title: "Information",
+  body: "All efforts have been taken to logically group the links found in the metadata record. If you believe an entry to incorrectly grouped please contact us at info@aodn.org.au",
+};
+
+const CodeTutorialsList: React.FC<CodeTutorialsListProps> = ({
+  title,
+  pythonNotebookLinks,
+  selected = false,
+}) => {
+  const pythonNotebookItems = pythonNotebookLinks?.map(
+    (link: ILink, index: number) => (
+      <ItemBaseGrid key={index}>
+        <LinkCard key={index} link={link} />
+      </ItemBaseGrid>
+    )
+  );
+
+  return (
+    <ExpandableList
+      selected={selected}
+      childrenList={pythonNotebookItems}
+      title={title}
+      info={INFO_TIP_CONTENT}
+    />
+  );
+};
+
+export default CodeTutorialsList;

--- a/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
@@ -22,6 +22,34 @@ export enum TYPE {
   DATA_ACCESS = "DATA_ACCESS",
 }
 
+const OPTIMIZED_PYTHON_NOTEBOOK_LINK_TITLE =
+  "Access to Jupyter notebook to query Cloud Optimised converted dataset";
+const PYTHON_NOTEBOOK_EXAMPLE_LINK = "Python notebook Example";
+
+// Only find optimized Python notebook links if they exist, otherwise fall back to example links
+const getOptimizedPythonNotebookLinks = (
+  links: ILink[] | undefined
+): ILink[] | undefined => {
+  if (!links) return undefined;
+
+  // First, try to find optimized Python notebook links
+  const optimizedLinks = links.filter(
+    (link) => link.title === OPTIMIZED_PYTHON_NOTEBOOK_LINK_TITLE
+  );
+
+  // If found, return them
+  if (optimizedLinks.length > 0) {
+    return optimizedLinks;
+  }
+
+  // Otherwise, fall back to example links
+  const exampleLinks = links.filter(
+    (link) => link.title === PYTHON_NOTEBOOK_EXAMPLE_LINK
+  );
+
+  return exampleLinks.length > 0 ? exampleLinks : undefined;
+};
+
 interface DataAccessPanelProps {
   mode?: MODE;
   type?: TYPE;
@@ -104,6 +132,18 @@ const DataAccessPanel: FC<DataAccessPanelProps> = ({ mode, type }) => {
             {...props}
             title={"Document"}
             documentLinks={collection?.getDocumentLinks()}
+          />
+        ),
+      },
+      {
+        title: "Code Tutorials",
+        component: (props: Record<string, any>) => (
+          <DocumentList
+            {...props}
+            title={"Code Tutorials"}
+            documentLinks={getOptimizedPythonNotebookLinks(
+              collection?.getPythonNotebookLinks()
+            )}
           />
         ),
       },


### PR DESCRIPTION
add Code Tutorials block to display optimized Python Notebook links which titles are:
```
const OPTIMIZED_PYTHON_NOTEBOOK_LINK_TITLE =
  "Access to Jupyter notebook to query Cloud Optimised converted dataset";
  
 // fallback:
const PYTHON_NOTEBOOK_EXAMPLE_LINK = "Python notebook Example";
```
the information come from Nat
please see ticket for reference
