### PR TITLE
Hide zoom control on below laptop screen

### DIFF
--- a/src/components/map/mapbox/component/GeoserverLayerSelect.tsx
+++ b/src/components/map/mapbox/component/GeoserverLayerSelect.tsx
@@ -12,6 +12,7 @@ import CommonSelect, {
   SelectItem,
 } from "../../../common/dropdown/CommonSelect";
 import rc8Theme from "../../../../styles/themeRC8";
+import useBreakpoint from "../../../../hooks/useBreakpoint";
 
 interface GeoserverLayerSelectProps {
   wmsLayersOptions: SelectItem<string>[];
@@ -27,6 +28,7 @@ const GeoserverLayerSelect: FC<GeoserverLayerSelectProps> = ({
   isLoading,
 }) => {
   const theme = useTheme();
+  const { isUnderLaptop } = useBreakpoint();
 
   const selectProps = {
     backgroundColor: "transparent",
@@ -62,7 +64,7 @@ const GeoserverLayerSelect: FC<GeoserverLayerSelectProps> = ({
         maxWidth: "70%",
         position: "absolute",
         top: 0,
-        left: "40px",
+        left: `${isUnderLaptop ? "0px" : "40px"}`,
         zIndex: zIndex.MAP_POPUP,
         padding: "10px",
       }}

--- a/src/components/map/mapbox/controls/NavigationControl.tsx
+++ b/src/components/map/mapbox/controls/NavigationControl.tsx
@@ -131,7 +131,6 @@ class StyledNavigationControl extends MapboxNavigationControl {
     map.on(MOVE_START, this.zoomButtonDisable);
     map.on(MOVE_END, this.zoomButtonEnable);
 
-    this.zoomButtonDisable();
     this.map = map;
     return this.container;
   }
@@ -191,4 +190,5 @@ const NavigationControl = ({
   return <React.Fragment />;
 };
 
+export { CONTAINER_MAP_ZOOM_ID };
 export default NavigationControl;

--- a/src/pages/detail-page/subpages/tab-panels/SummaryAndDownloadPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/SummaryAndDownloadPanel.tsx
@@ -38,6 +38,7 @@ import { DatasetType } from "../../../../components/common/store/OGCCollectionDe
 import ReferenceLayerSwitcher from "../../../../components/map/mapbox/controls/menu/ReferenceLayerSwitcher";
 import MenuControlGroup from "../../../../components/map/mapbox/controls/menu/MenuControlGroup";
 import GeojsonLayer from "../../../../components/map/mapbox/layers/GeojsonLayer";
+import useBreakpoint from "../../../../hooks/useBreakpoint";
 
 const mapContainerId = "map-detail-container-id";
 
@@ -106,6 +107,8 @@ const SummaryAndDownloadPanel: FC<SummaryAndDownloadPanelProps> = ({
   const [staticLayer, setStaticLayer] = useState<Array<string>>([]);
   const [isWMSAvailable, setIsWMSAvailable] = useState<boolean>(true);
   const [timeSliderSupport, setTimeSliderSupport] = useState<boolean>(true);
+
+  const { isUnderLaptop } = useBreakpoint();
 
   const abstract = useMemo(
     () => collection?.getEnhancedDescription() || collection?.description || "",
@@ -343,7 +346,7 @@ const SummaryAndDownloadPanel: FC<SummaryAndDownloadPanelProps> = ({
                   onZoomEvent={handleMapChange}
                 >
                   <Controls>
-                    <NavigationControl />
+                    <NavigationControl visible={!isUnderLaptop} />
                     <ScaleControl />
                     <DisplayCoordinate />
                     <MenuControlGroup>


### PR DESCRIPTION
We use finger to zoom in and out, no point to show the zoom button on small screen, so we can see zoom button on PC but not on small device