### PR TITLE
Fix bug on search get cancel accidentally

### DIFF
--- a/playwright/tests/search_page/test_map.py
+++ b/playwright/tests/search_page/test_map.py
@@ -385,7 +385,6 @@ def test_map_resets_to_default_after_landing_page(desktop_page: Page) -> None:
     assert are_value_equal(current_map_zoom, default_map_zoom)
     assert are_coordinates_equal(current_map_center, default_map_center)
 
-@pytest.mark.skip("untable")
 @pytest.mark.parametrize(
     'data_id, data_lng, data_lat',
     [
@@ -422,7 +421,6 @@ def test_map_card_popup_download_button_in_desktop(
     expect(search_page.main_map).to_be_visible()
 
 
-@pytest.mark.skip("unstable")
 @pytest.mark.parametrize(
     'data_id',
     [

--- a/playwright/tests/search_page/test_search.py
+++ b/playwright/tests/search_page/test_search.py
@@ -49,7 +49,7 @@ def test_basic_search(
     expect(search_page.search.search_field).to_have_value(category_name)
     expect(search_page.first_result_title).to_be_visible()
 
-@pytest.mark.skip("untable")
+
 @pytest.mark.parametrize(
     'sort_type',
     [SearchSortType.TITLE, SearchSortType.MODIFIED],

--- a/playwright/tests/search_page/test_search_page.py
+++ b/playwright/tests/search_page/test_search_page.py
@@ -6,7 +6,6 @@ from pages.landing_page import LandingPage
 from pages.search_page import SearchPage
 
 
-@pytest.mark.skip("unstable")
 def test_map_full_screen_toggle(desktop_page: Page) -> None:
     """
     Verifies that the map can be toggled to full screen and back

--- a/src/analytics/searchParamsEvent.ts
+++ b/src/analytics/searchParamsEvent.ts
@@ -55,15 +55,13 @@ export function trackSearchResultParameters(searchParams: SearchParameters) {
     if (!filter) return "";
 
     // Remove BBOX and page_size (technical parameters)
-    const userFilter = filter
+    return filter
       .replace(/\s+AND\s+BBOX[^)]+\)/g, "") // Remove BBOX
       .replace(/\s+AND\s+INTERSECTS[^)]+\)\)\)/g, "") // Remove INTERSECTS
       .replace(/page_size=\d+\s+AND\s+/g, "") // Remove page_size
       .replace(/\s+AND\s+/g, " AND ") // Clean up multiple ANDs
       .replace(/^AND\s+|AND\s+$/g, "") // Remove leading/trailing AND
       .trim();
-
-    return userFilter;
   };
 
   const searchKey = `${searchParams.text || ""}_${searchParams.sortby || ""}_${extractUserFilters(searchParams.filter || "")}`;

--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -169,8 +169,8 @@ const searchResult = async (
     p.sortby = param.sortby;
   }
 
-  // Track search page url parameters
-  trackSearchResultParameters(param);
+  // Track search page url parameters, do not block the search
+  setTimeout(() => trackSearchResultParameters(param), 500);
 
   return ogcAxiosWithRetry
     .get<string>("/ogc/collections", {

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -151,14 +151,6 @@ const SearchPage = () => {
       );
       // Make sure no other code abort the search
       if (mapSearchAbortRef.current) {
-        // Update URL earlier as map take time to search, so user may copy incorrect URL during
-        // search and make sure no one cancel the search
-        if (needNavigate) {
-          debounceHistoryUpdateRef?.current?.cancel();
-          debounceHistoryUpdateRef?.current?.(
-            pageDefault.search + "?" + formatToUrlParam(componentParam)
-          );
-        }
         dispatch(
           // add param "sortby: id" for fetchResultNoStore to ensure data source for map is always sorted
           // and ordered by uuid to avoid affecting cluster calculation
@@ -182,6 +174,16 @@ const SearchPage = () => {
               booleanEqual(componentParam.bbox, current)
             ) {
               setLayers(jsonToOGCCollections(collections).collections);
+            }
+          })
+          .then(() => {
+            // Must update status after search done, this change the location.state and will
+            // cause all search cancel
+            if (needNavigate) {
+              debounceHistoryUpdateRef?.current?.cancel();
+              debounceHistoryUpdateRef?.current?.(
+                pageDefault.search + "?" + formatToUrlParam(componentParam)
+              );
             }
           })
           .catch(() => {


### PR DESCRIPTION
The if(needNavigate) is calling before the dispatch(...), the navigate will cause the location.state update and accidentally trigger

````
  useEffect(() => {
    const handleNavigation = () => {
      const reduxContents = getSearchQueryResult(store.getState());
      if (
        location.state?.referer === pageReferer.SEARCH_PAGE_REFERER &&
        location.state?.requireSearch === false
      ) {
        // If the referer is SEARCH_PAGE_REFERER, it means the user is interacting with the search page
        // Meanwhile if the state requireSearch is false, it means the user is not required to do a search. This happens when user just change the layout
        // However the referer = SEARCH_PAGE_REFERER and requireSearch = false will be persist but redux will be cleared when user refresh the page, so we need to do a full search
        // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or no search
        if (reduxContents.result.total > 0) {
          return;
        } else {
          doListSearch();
        }
      } else if (
        // If user navigate from DetailPage, as the redux store has results content already we just need to do a map search
        // However when user refresh the page, the redux will be cleared, we need to do a full search
        // Therefore we need to check if the redux content is empty or not to decide whether to do a full search or only map search
        location.state?.referer === pageReferer.DETAIL_PAGE_REFERER &&
        location.state?.requireSearch === false
      ) {
        if (reduxContents.result.total > 0) {
          doMapSearch()?.finally(() => {});
        } else {
          doListSearch();
        }
      } else {
        // In other cases, we need to do a full search
        // This including (but not limit): user pastes the url directly, navigate from landing page, change sort ...
        doListSearch();
      }
    };
    handleNavigation();

    return () => {
      cancelAllSearch();
    };
    // Must use location.state as the value inside can be the same reference, and hence will not trigger execution
    // the state object will be different each time.
  }, [cancelAllSearch, doListSearch, doMapSearch, location.state]);

````

and cause the cancelAllSearch() called. There is a small delay on this useEffect() being invoke and therefore sometime search get cancel sometimes not.