### PR TITLE
Fix layer name

### DIFF
--- a/src/components/map/mapbox/controls/DisplayCoordinate.tsx
+++ b/src/components/map/mapbox/controls/DisplayCoordinate.tsx
@@ -30,7 +30,8 @@ const DisplayCoordinate = () => {
       ref={ref}
       style={{
         display: "inline-block",
-        position: "relative",
+        position: "absolute",
+        bottom: 0,
         zIndex: zIndex["MAP_COORD"],
         backgroundColor: "rgba(255, 255, 255, 0.6)",
       }}

--- a/src/components/map/mapbox/layers/GeoServerLayer.tsx
+++ b/src/components/map/mapbox/layers/GeoServerLayer.tsx
@@ -139,10 +139,24 @@ const formWmsLayerOptions = (
   }));
 };
 
+const extractLayerName = (layer: ILink): string => {
+  // Two ways to use the wms like, either you put the layer name in title or you put a description and then
+  // give a link to wms, now if it is the later case then we try to see if the url have attribute layer name there
+  // if yes we use it otherwise we use the title.
+  if (layer.href) {
+    const url = new URL(layer.href);
+    const ln = url.searchParams.get("layers");
+    if (ln) {
+      return ln;
+    }
+  }
+  return layer.title;
+};
+
 const formWmsLinkOptions = (layers: ILink[] | undefined): SelectItem[] => {
   if (!layers || layers.length === 0) return [];
   return layers?.map((layer) => ({
-    value: layer.title,
+    value: extractLayerName(layer),
     label: layer.title, // Use title for label for now. Could be changed to ai:label in future
   }));
 };


### PR DESCRIPTION
The layer name is not always the title name, if the user have a valid URL contains layername use that one instead of title.