### PR TITLE
Fix issue with fitBounds missing after method changed

### DIFF
--- a/src/components/bookmark/BookmarkListCard.tsx
+++ b/src/components/bookmark/BookmarkListCard.tsx
@@ -9,6 +9,7 @@ import { padding } from "../../styles/constants";
 import { TabNavigation } from "../../hooks/useTabNavigation";
 import { detailPageDefault, pageReferer } from "../common/constants";
 import rc8Theme from "../../styles/themeRC8";
+import FitToSpatialExtentsLayer from "../map/mapbox/layers/FitToSpatialExtentsLayer";
 
 export interface BookmarkListCardType {
   dataset: OGCCollection;
@@ -51,6 +52,7 @@ const BookmarkListCard: FC<BookmarkListCardProps> = ({
             }
           >
             <Layers>
+              <FitToSpatialExtentsLayer collection={dataset} />
               <GeojsonLayer
                 collection={dataset}
                 animate={false}

--- a/src/components/common/hover-tip/ComplexMapHoverTip.tsx
+++ b/src/components/common/hover-tip/ComplexMapHoverTip.tsx
@@ -15,6 +15,7 @@ import GeojsonLayer from "../../map/mapbox/layers/GeojsonLayer";
 import BookmarkButton from "../../bookmark/BookmarkButton";
 import { TabNavigation } from "../../../hooks/useTabNavigation";
 import { detailPageDefault, pageReferer } from "../constants";
+import FitToSpatialExtentsLayer from "../../map/mapbox/layers/FitToSpatialExtentsLayer";
 
 interface BasicMapHoverTipProps {
   content?: string | undefined | null;
@@ -95,6 +96,7 @@ const ComplexMapHoverTip: FC<ComplexMapHoverTipProps> = ({
         >
           <Map panelId={`${mapContainerId}-${collection.id}`}>
             <Layers>
+              <FitToSpatialExtentsLayer collection={collection} />
               <GeojsonLayer
                 collection={collection}
                 animate={false}

--- a/src/components/map/mapbox/component/CardPopup.tsx
+++ b/src/components/map/mapbox/component/CardPopup.tsx
@@ -28,6 +28,7 @@ import ResultCardButtonGroup from "../../../result/ResultCardButtonGroup";
 import BookmarkButton from "../../../bookmark/BookmarkButton";
 import { detailPageDefault, pageReferer } from "../../../common/constants";
 import { MapEventEnum } from "../constants";
+import FitToSpatialExtentsLayer from "../layers/FitToSpatialExtentsLayer";
 
 interface CardPopupProps {
   layerId: string;
@@ -204,6 +205,7 @@ const CardPopup: React.FC<CardPopupProps> = ({
               animate={false}
             >
               <Layers>
+                <FitToSpatialExtentsLayer collection={content} />
                 <GeojsonLayer collection={content} visible={true} />
               </Layers>
             </Map>

--- a/src/pages/detail-page/subpages/side-cards/SpatialCoverageCard.tsx
+++ b/src/pages/detail-page/subpages/side-cards/SpatialCoverageCard.tsx
@@ -6,6 +6,7 @@ import Layers from "../../../../components/map/mapbox/layers/Layers";
 import GeojsonLayer from "../../../../components/map/mapbox/layers/GeojsonLayer";
 import { FC, useCallback } from "react";
 import { Popup, MapMouseEvent } from "mapbox-gl";
+import FitToSpatialExtentsLayer from "../../../../components/map/mapbox/layers/FitToSpatialExtentsLayer";
 
 export interface SpatialCoverageCardProps {
   onSpatialCoverageLayerClick?: (event: MapMouseEvent) => void;
@@ -52,6 +53,7 @@ const SpatialCoverageCard: FC<SpatialCoverageCardProps> = ({
         >
           <Map panelId={mapContainerId} zoom={0} minZoom={0}>
             <Layers>
+              <FitToSpatialExtentsLayer collection={collection} />
               <GeojsonLayer
                 collection={collection}
                 onLayerClick={onSpatialCoverageLayerClick}


### PR DESCRIPTION
After refactor and move the fit to bounds action outside geojson layer to avoid any one who use it will auto fit to bounds and other layer will not auto fit , so if layers use together it is hard to code who is going to do the fit action.

This fix the issue where we need to add the fit operation on those who assume fit by default