### PR TITLE
Fix map search cancel incorrectly

### DIFF
--- a/playwright/tests/search_page/sort_and_view_memory/test_states.py
+++ b/playwright/tests/search_page/sort_and_view_memory/test_states.py
@@ -106,8 +106,9 @@ def test_sort_and_view_states_persist_after_map_toggle(
     search_page.click_text(view_type.display_name, exact=True)
 
     search_page.map_toggle_button.click()
-    search_page.map_toggle_button.click()
+    search_page.map.wait_for_map_idle()
 
+    search_page.map_toggle_button.click()
     search_page.map.wait_for_map_idle()
 
     expect(

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -226,7 +226,6 @@ const SearchPage = () => {
           // If another zoom or move starts, we can cancel the current map search
           // as it is useless because another zoom/move end will come and trigger
           // search again
-          console.log("Cancel devom ot eu / zoom");
           mapSearchAbortRef.current?.abort();
           mapSearchAbortRef.current = null;
         } else if (


### PR DESCRIPTION
Under dev strict mode, the useEffect render twice, hence hide the problem that the map search cancel incorrectly. A checking added to tell if it is init from user or from map api. If init by api, do not cancel search