### PR TITLE
add the playwright-local env to avoid confuse with "dev" run

### DIFF
--- a/.env.config.dev
+++ b/.env.config.dev
@@ -2,7 +2,6 @@
 
 # Use for local development only, server side use cloudfront for proxy redirect
 VITE_API_HOST=http://localhost:8080/
-VITE_GWC_WMS=https://tilecache.aodn.org.au/geowebcache/service/wms
 
 # These access token cannot sore in secret store due nature of static website
 VITE_MAPBOX_ACCESS_TOKEN=

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest",
     "test:debug": "vitest --run --reporter=verbose --watch=false",
     "playwright": "docker compose -f playwright/docker-compose.yml up --abort-on-container-exit --exit-code-from tests",
+    "playwright-local": "bash generateEnv.sh dev && vitest run && vite --mode playwright-local --host 0.0.0.0",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/playwright/Dockerfile.web
+++ b/playwright/Dockerfile.web
@@ -18,4 +18,4 @@ RUN \
 EXPOSE 5173
 
 # Command to run the application
-CMD ["yarn", "dev", "--host", "0.0.0.0"]
+CMD ["yarn", "playwright-local", "--host", "0.0.0.0"]

--- a/src/components/common/test/helper.tsx
+++ b/src/components/common/test/helper.tsx
@@ -20,7 +20,7 @@ interface TestProps {
 // Use in test only to expose reference that need by test e2e testing.
 const TestHelper: React.FC<TestProps> = (props) => {
   useEffect(() => {
-    if (import.meta.env.MODE === "dev") {
+    if (import.meta.env.MODE === "playwright-local") {
       const { id, ...restProps } = props;
       const getMap = restProps.getMap;
 

--- a/src/components/map/mapbox/Map.tsx
+++ b/src/components/map/mapbox/Map.tsx
@@ -121,7 +121,7 @@ const ReactMap = memo(
           style: styles[MapDefaultConfig.DEFAULT_STYLE].style,
           minZoom: minZoom,
           maxZoom: maxZoom,
-          testMode: import.meta.env.MODE === "dev",
+          testMode: import.meta.env.MODE === "playwright-local",
           attributionControl: true,
           localIdeographFontFamily:
             "'Open Sans', 'Open Sans CJK SC', sans-serif",
@@ -192,7 +192,7 @@ const ReactMap = memo(
         );
         resizeObserver.observe(map.getContainer());
 
-        if (import.meta.env.MODE === "dev") {
+        if (import.meta.env.MODE === "playwright-local") {
           //map.showPadding = true;
           //map.showCollisionBoxes = true;
         }


### PR DESCRIPTION
In playwright test, we move the map via API, however in the code we only consider user action as valid action , like mouse move is valid if it is user init, not api init.

That case some playwright test fail, before this change we use "dev" env to indicate it is a playwright test together with normal pc local run, this is confuse and make some before not as expected for local run. Hence introduce a playwright-local env