### PR TITLE
:bug: fix click spatial coverage map navigation

### DIFF
--- a/src/components/map/mapbox/layers/FitToSpatialExtentsLayer.tsx
+++ b/src/components/map/mapbox/layers/FitToSpatialExtentsLayer.tsx
@@ -30,9 +30,17 @@ const FitToSpatialExtentsLayer: FC<FitToSpatialExtentsLayerProps> = ({
         map.getBounds()?.getEast() !== bbox?.getEast() ||
         map.getBounds()?.getNorth() !== bbox?.getNorth()
       ) {
+        // If style is already loaded, fit to bound immediately
+        if (map.isStyleLoaded()) {
+          fitToBound(map, b[0]);
+          return;
+        }
+
         // This make the event fired earlier than IDLE which makes the map move to place
         // during rendering
-        map.once(MapEventEnum.RENDER, () => fitToBound(map, b[0]));
+        map.once(MapEventEnum.RENDER, () => {
+          return fitToBound(map, b[0]);
+        });
       }
     }
   }, [bbox, collection, map]);

--- a/src/pages/detail-page/subpages/tab-panels/SummaryAndDownloadPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/SummaryAndDownloadPanel.tsx
@@ -271,6 +271,27 @@ const SummaryAndDownloadPanel: FC<SummaryAndDownloadPanelProps> = ({
     return [conditionStart, conditionEnd];
   }, [downloadConditions]);
 
+  const geoServerLayerConfig = useMemo(() => {
+    return discreteTimeSliderValues
+      ? {
+          urlParams: {
+            TIME: dayjs.utc(datePointValue!),
+            MODE: Dimension.SINGLE,
+          },
+        }
+      : {
+          urlParams: {
+            START_DATE: filterStartDate,
+            END_DATE: filterEndDate,
+          },
+        };
+  }, [
+    discreteTimeSliderValues,
+    datePointValue,
+    filterStartDate,
+    filterEndDate,
+  ]);
+
   const handleMapChange = useCallback(
     (event: MapEvent | undefined) => {
       // implement later
@@ -530,23 +551,7 @@ const SummaryAndDownloadPanel: FC<SummaryAndDownloadPanelProps> = ({
                     onSelectCoKey={setSelectedCoKey}
                   />
                   <GeoServerLayer
-                    geoServerLayerConfig={
-                      // This value appears only if this dataset layer support single time
-                      // move, NOT range
-                      discreteTimeSliderValues
-                        ? {
-                            urlParams: {
-                              TIME: dayjs.utc(datePointValue!),
-                              MODE: Dimension.SINGLE,
-                            },
-                          }
-                        : {
-                            urlParams: {
-                              START_DATE: filterStartDate,
-                              END_DATE: filterEndDate,
-                            },
-                          }
-                    }
+                    geoServerLayerConfig={geoServerLayerConfig}
                     onWMSAvailabilityChange={onWMSAvailabilityChange}
                     onWFSAvailabilityChange={onWFSAvailabilityChange}
                     onWmsLayerChange={onWmsLayerChange}


### PR DESCRIPTION
~~1 in Geojson layer, on layer click, query the clicked bbox and pass to FitToSpatilaExtentsLayer for fitting to~~
2 `map.once(MapEventEnum.RENDER, () => fitToBound(map, b[0]))` does not run for bbox changing once the map is rendered and idle, so for bbox update we just call `fitToBound` if the style is loaded

uuid: 48cf3cb9-caa9-4633-9baa-8bba3c4d904a

<img width="2898" height="1186" alt="image" src="https://github.com/user-attachments/assets/ff7d2c3b-a2d2-4dcb-b050-cdd5af9a63cb" />