### PR TITLE
:bug: fix download size format and wrapping

### DIFF
--- a/src/components/common/buttons/DownloadButton.tsx
+++ b/src/components/common/buttons/DownloadButton.tsx
@@ -2,49 +2,73 @@ import { FC } from "react";
 import {
   Button,
   CircularProgress,
+  Stack,
   SxProps,
   Tooltip,
   Typography,
 } from "@mui/material";
 import { portalTheme } from "../../../styles";
 import { DownloadIcon } from "../../../assets/icons/download/download";
+import { formatBytes } from "../../../utils/Helpers";
 
 interface DownloadButtonProps {
   onDownload: () => void;
   isDownloading?: boolean;
   isEstimating?: boolean;
-  estimatedSizeMB?: number | null;
+  estimatedSizeBytes?: number | null;
   sx?: SxProps;
 }
-const getSizeLabel = (estimatedSizeMB: number | null) =>
-  estimatedSizeMB != null ? ` [~${estimatedSizeMB} MB]` : "";
-
-const getButtonLabel = (isDownloading: boolean, sizeLabel: string) =>
-  isDownloading ? `Downloading...${sizeLabel}` : `Download${sizeLabel}`;
 
 const getTooltip = (
   isDownloading: boolean,
   isEstimating: boolean,
-  estimatedSizeMB: number | null
+  estimatedSizeBytes: number | null
 ) =>
   isDownloading
     ? "Downloading data"
     : isEstimating
       ? "Estimating download size..."
-      : estimatedSizeMB != null
-        ? `Download data is approximately ${estimatedSizeMB} MB`
+      : estimatedSizeBytes != null
+        ? `Download data is approximately ${formatBytes(estimatedSizeBytes)}`
         : "Download data";
+
+const renderButtonLabel = (
+  isDownloading: boolean,
+  estimatedSizeBytes: number | null
+) => (
+  <Stack
+    direction="row"
+    sx={{ flexWrap: "wrap", justifyContent: "center", gap: 0.5 }}
+  >
+    <Typography
+      typography="title1Medium"
+      color={portalTheme.palette.text3}
+      padding={0}
+    >
+      {isDownloading ? "Downloading..." : "Download"}
+    </Typography>
+    {estimatedSizeBytes != null && (
+      <Typography
+        typography="title1Medium"
+        color={portalTheme.palette.text3}
+        padding={0}
+      >
+        {`[~${formatBytes(estimatedSizeBytes)}]`}
+      </Typography>
+    )}
+  </Stack>
+);
 
 const DownloadButton: FC<DownloadButtonProps> = ({
   onDownload,
   isDownloading = false,
   isEstimating = false,
-  estimatedSizeMB = null,
+  estimatedSizeBytes = null,
   sx,
 }) => {
   return (
     <Tooltip
-      title={getTooltip(isDownloading, isEstimating, estimatedSizeMB)}
+      title={getTooltip(isDownloading, isEstimating, estimatedSizeBytes)}
       placement="top"
     >
       <Button
@@ -62,13 +86,7 @@ const DownloadButton: FC<DownloadButtonProps> = ({
         onClick={isDownloading ? undefined : () => onDownload()}
       >
         <DownloadIcon />
-        <Typography
-          typography="title1Medium"
-          color={portalTheme.palette.text3}
-          padding={0}
-        >
-          {getButtonLabel(isDownloading, getSizeLabel(estimatedSizeMB ?? null))}
-        </Typography>
+        {renderButtonLabel(isDownloading, estimatedSizeBytes ?? null)}
         {isEstimating && !isDownloading && (
           <CircularProgress
             size={14}

--- a/src/hooks/useWFSDownload.tsx
+++ b/src/hooks/useWFSDownload.tsx
@@ -72,14 +72,6 @@ const useWFSDownload = (onCallback?: () => void) => {
   const expectedTotalChunksRef = useRef<number>(0);
 
   // Helper functions
-  const formatBytes = (bytes: number) => {
-    if (bytes === 0) return "0 Bytes";
-    const k = 1024;
-    const sizes = ["Bytes", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-  };
-
   const generateFileName = (layerName: string) => {
     const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, "-");
     const sanitizedLayerName = layerName.replace(/[^a-z0-9]/gi, "_");
@@ -381,7 +373,6 @@ const useWFSDownload = (onCallback?: () => void) => {
     progressMessage,
     startDownload,
     cancelDownload,
-    formatBytes,
     isDownloading:
       downloadingStatus === DownloadStatus.IN_PROGRESS ||
       downloadingStatus === DownloadStatus.WAITING_SERVER,

--- a/src/hooks/useWFSEstimateSize.tsx
+++ b/src/hooks/useWFSEstimateSize.tsx
@@ -29,11 +29,11 @@ enum EstimateStatus {
   ERROR = "error",
 }
 
-const BYTES_PER_MB = 1024 * 1024;
-
 const useWFSEstimateSize = () => {
   const dispatch = useAppDispatch();
-  const [estimatedSizeMB, setEstimatedSizeMB] = useState<number | null>(null);
+  const [estimatedSizeBytes, setEstimatedSizeBytes] = useState<number | null>(
+    null
+  );
   const [status, setStatus] = useState<EstimateStatus>(EstimateStatus.IDLE);
   const estimatePromiseRef = useRef<any>(null);
 
@@ -59,7 +59,7 @@ const useWFSEstimateSize = () => {
 
       if (!uuid || !layerName) return;
 
-      setEstimatedSizeMB(null);
+      setEstimatedSizeBytes(null);
       setStatus(EstimateStatus.ESTIMATING);
 
       try {
@@ -93,9 +93,7 @@ const useWFSEstimateSize = () => {
 
             case EstimateEventName.ESTIMATE_COMPLETE:
               if (eventData.size !== undefined) {
-                setEstimatedSizeMB(
-                  parseFloat((eventData.size / BYTES_PER_MB).toFixed(2))
-                );
+                setEstimatedSizeBytes(eventData.size);
               }
               setStatus(EstimateStatus.COMPLETED);
               break;
@@ -113,7 +111,7 @@ const useWFSEstimateSize = () => {
   );
 
   return {
-    estimatedSizeMB,
+    estimatedSizeBytes,
     isEstimating: status === EstimateStatus.ESTIMATING,
     estimateSize,
     cancelEstimate,

--- a/src/pages/detail-page/subpages/side-cards/download-card/components/DownloadWFSCard.tsx
+++ b/src/pages/detail-page/subpages/side-cards/download-card/components/DownloadWFSCard.tsx
@@ -36,6 +36,7 @@ import { useAppDispatch } from "../../../../../../components/common/store/hooks"
 import { SelectItem } from "../../../../../../components/common/dropdown/CommonSelect";
 import { fetchGeoServerDownloadLayers } from "../../../../../../components/common/store/searchReducer";
 import AdminScreenContext from "../../../../../../components/admin/AdminScreenContext";
+import { formatBytes } from "../../../../../../utils/Helpers";
 
 // Currently only CSV is supported for WFS downloading
 // TODO:the format options will be fetched from the backend in the future
@@ -72,10 +73,9 @@ const DownloadWFSCard: FC<DownloadWFSCardProps> = ({
     progressMessage,
     startDownload,
     cancelDownload,
-    formatBytes,
     isDownloading,
   } = useWFSDownload(() => setSnackbarOpen(true));
-  const { estimatedSizeMB, isEstimating, estimateSize, cancelEstimate } =
+  const { isEstimating, estimateSize, cancelEstimate, estimatedSizeBytes } =
     useWFSEstimateSize();
   const dispatch = useAppDispatch();
   const { enableGeoServerWhiteList } = useContext(AdminScreenContext);
@@ -255,7 +255,7 @@ const DownloadWFSCard: FC<DownloadWFSCardProps> = ({
             onDownload={handleDownload}
             isDownloading={isDownloading}
             isEstimating={isEstimating}
-            estimatedSizeMB={estimatedSizeMB}
+            estimatedSizeBytes={estimatedSizeBytes}
           />
           {isDownloading && (
             <Box sx={{ position: "absolute", right: 1, top: 1 }}>

--- a/src/utils/Helpers.tsx
+++ b/src/utils/Helpers.tsx
@@ -74,3 +74,22 @@ export const removeDuplicatesAndEmpty = (items: string[]): string[] => {
       return true;
     });
 };
+
+/**
+ * Formats a number of bytes into a human-readable string with appropriate units.
+ *
+ * @param bytes The number of bytes to format
+ * @returns A formatted string representing the size in Bytes, KB, MB, or GB
+ *
+ * @example
+ * formatBytes(1024); // "1 KB"
+ * formatBytes(1048576); // "1 MB"
+ * formatBytes(1073741824); // "1 GB"
+ */
+export const formatBytes = (bytes: number): string => {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+};

--- a/src/utils/__test__/Helpers.test.ts
+++ b/src/utils/__test__/Helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes } from "../Helpers";
+
+describe("formatBytes", () => {
+  it("returns '0 Bytes' for zero", () => {
+    expect(formatBytes(0)).toBe("0 Bytes");
+  });
+
+  it("formats bytes under 1 KB", () => {
+    expect(formatBytes(500)).toBe("500 Bytes");
+  });
+
+  it("formats exact kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+  });
+
+  it("formats values in KB range", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("formats exact megabytes", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1 MB");
+  });
+
+  it("formats values in MB range", () => {
+    expect(formatBytes(2.5 * 1024 * 1024)).toBe("2.5 MB");
+  });
+
+  it("formats exact gigabytes", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1 GB");
+  });
+
+  it("formats large byte values from estimate-complete SSE payload", () => {
+    // 236231682 bytes ≈ 225.29 MB
+    expect(formatBytes(236231682)).toBe("225.29 MB");
+  });
+});


### PR DESCRIPTION
**change format to include KB, MB and GB, so in most cases text won't get truncated**
<img width="1061" height="443" alt="Image" src="https://github.com/user-attachments/assets/6c3fc0ec-4a34-42f2-a4b8-0c7f05b71993" />

**wrap text to two lines if it's too long in special screen size**
<img width="1061" height="443" alt="Image" src="https://github.com/user-attachments/assets/d5045814-7bab-4066-9bcf-2c2ebf769cea" />