### PR TITLE
Bugfix/7524 banner text mobile misalign

### DIFF
--- a/src/pages/landing-page/subpages/banner/Banner.tsx
+++ b/src/pages/landing-page/subpages/banner/Banner.tsx
@@ -1,12 +1,7 @@
 import { useState } from "react";
 import { Box, Dialog, Stack, Tooltip, Typography } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
-import {
-  fontSize,
-  fontWeight,
-  gap,
-  padding,
-} from "../../../../styles/constants";
+import { padding } from "../../../../styles/constants";
 import useBreakpoint from "../../../../hooks/useBreakpoint";
 import bannerImage1 from "@/assets/images/banner_image_1.png";
 import bannerImage2 from "@/assets/images/banner_image_2.png";
@@ -23,45 +18,31 @@ const renderBannerText = () => {
         data-testid="hero-text"
       >
         <Typography
+          variant="slogan2"
           sx={{
-            fontSize: {
-              xs: fontSize.bannerTitleSmall,
-              sm: fontSize.bannerTitleMedium,
-              xl: fontSize.bannerTitleLarge,
-            },
-            letterSpacing: gap.xs,
-            fontWeight: fontWeight.light,
             color: portalTheme.palette.text2,
             textAlign: "left",
-            padding: 0,
+            p: padding.nil,
           }}
         >
           IMOS Australian
         </Typography>
         <Typography
+          variant="slogan1"
           sx={{
-            fontSize: {
-              xs: fontSize.bannerTitleMedium,
-              sm: fontSize.bannerTitleLarge,
-              xl: fontSize.bannerTitleExtraLarge,
-            },
-            letterSpacing: gap.xs,
-            fontWeight: fontWeight.bold,
             color: portalTheme.palette.text2,
             textAlign: "left",
-            padding: 0,
-            mt: -2,
+            p: padding.nil,
           }}
         >
           Ocean Data Portal
         </Typography>
         <Typography
+          variant="slogan3"
           sx={{
-            ...portalTheme.typography.heading4,
             color: portalTheme.palette.text2,
             whiteSpace: "wrap",
-            p: 0,
-            pr: padding.small,
+            p: padding.nil,
           }}
         >
           &quot;Open access to Australian marine and climate science

--- a/src/styles/constants.ts
+++ b/src/styles/constants.ts
@@ -41,32 +41,15 @@ const padding = {
   triple: "45px",
   quadruple: "60px",
 };
-
+// Should only remove, do not add, use theme please
 const fontSize = {
-  AODNSiteLogoText: "17px",
-  AODNSiteLogoTextMobile: "14px",
-  bannerTitleExtraLarge: "64px",
-  bannerTitleLarge: "48px",
-  bannerTitleMedium: "36px",
-  bannerTitleSmall: "28px",
-  bannerSubtitle: "16px",
-  bannerSubtitleSmall: "10px",
-  mapMenuItem: 14,
-  mapMenuSubItem: 13,
-  detailPageHeading: "20px",
-  detailPageHeadingMobile: "14px",
   newsHeading: "40px",
   newsTitle: "20px",
-  slideCardTitle: "16px",
-  slideCardSubTitle: "14px",
-  newsLabel: "16px",
   newsInfo: "14px",
   subscription: "14px",
   icon: "10px",
   label: "12px",
   info: "14px",
-  resultCardTitle: "14px",
-  resultCardTitleUnderLaptop: "12px",
   resultCardContent: "12px",
   resultCardContentUnderLaptop: "12px",
 };

--- a/src/styles/designTokensRC8.ts
+++ b/src/styles/designTokensRC8.ts
@@ -14,6 +14,7 @@
  * @version RC8
  */
 
+import { fontStyle } from "@mui/system";
 import { FONT_FAMILIES } from "./fontsRC8";
 
 export const designTokensRC8 = {
@@ -32,7 +33,7 @@ export const designTokensRC8 = {
       // Slogan styles - Size: 64, Line Height: 96
       slogan1: {
         fontFamily: FONT_FAMILIES.poppins,
-        fontSize: "64px",
+        fontStyle: "normal",
         fontWeight: 500,
         lineHeight: "96px",
         color: "#090C02",
@@ -41,10 +42,18 @@ export const designTokensRC8 = {
       // Slogan styles - Size: 48, Line Height: 72
       slogan2: {
         fontFamily: FONT_FAMILIES.poppins,
-        fontSize: "48px",
-        fontWeight: 300,
+        fontStyle: "normal",
+        fontWeight: 275,
         lineHeight: "72px",
         color: "#090C02",
+      },
+
+      // Slogan styles - Size: 48, Line Height: 72
+      slogan3: {
+        fontFamily: FONT_FAMILIES.openSans,
+        fontWeight: 400,
+        lineHeight: "22px",
+        color: "#3C3C3C",
       },
 
       // Heading styles - Size: 40, Line Height: 48

--- a/src/styles/themeRC8.ts
+++ b/src/styles/themeRC8.ts
@@ -34,7 +34,8 @@ const rc8ThemeOptions: ThemeOptions = {
       },
       // Laptop
       [defaultTheme.breakpoints.between("md", "lg")]: {
-        fontSize: "64px",
+        fontSize: "40px",
+        lineHeight: "40px",
       },
       // Desktop
       [defaultTheme.breakpoints.between("lg", "xl")]: {

--- a/src/styles/themeRC8.ts
+++ b/src/styles/themeRC8.ts
@@ -1,8 +1,10 @@
 import { createTheme, ThemeOptions } from "@mui/material/styles";
 import { designTokensRC8 as designTokens } from "./designTokensRC8";
 
-// Type definitions are in rc8ThemeTypes.ts to extend Material-UI theme interfaces
+// We create this just to get the helper methods
+const defaultTheme = createTheme();
 
+// Type definitions are in rc8ThemeTypes.ts to extend Material-UI theme interfaces
 const rc8ThemeOptions: ThemeOptions = {
   designTokens: designTokens,
 
@@ -12,8 +14,112 @@ const rc8ThemeOptions: ThemeOptions = {
       designTokens.typography.fontFamily.openSans,
     ].join(","),
 
-    slogan1: designTokens.typography.variants.slogan1,
-    slogan2: designTokens.typography.variants.slogan2,
+    slogan1: {
+      // Default
+      ...designTokens.typography.variants.slogan1,
+      // Mobile
+      [defaultTheme.breakpoints.down("sm")]: {
+        fontSize: "36px",
+        lineHeight: "40px",
+      },
+      // Tablet
+      [defaultTheme.breakpoints.between("sm", "md")]: {
+        fontSize: "36px",
+        lineHeight: "40px",
+      },
+      // Underlaptop
+      [defaultTheme.breakpoints.down("md")]: {
+        fontSize: "36px",
+        lineHeight: "40px",
+      },
+      // Laptop
+      [defaultTheme.breakpoints.between("md", "lg")]: {
+        fontSize: "64px",
+      },
+      // Desktop
+      [defaultTheme.breakpoints.between("lg", "xl")]: {
+        fontSize: "64px",
+      },
+      // Above desktop
+      [defaultTheme.breakpoints.up("lg")]: {
+        fontSize: "64px",
+      },
+      // 4K
+      [defaultTheme.breakpoints.up("xl")]: {
+        fontSize: "64px",
+      },
+    },
+    slogan2: {
+      // Default
+      ...designTokens.typography.variants.slogan2,
+      // Mobile
+      [defaultTheme.breakpoints.down("sm")]: {
+        fontSize: "30px",
+        lineHeight: "44px",
+      },
+      // Tablet
+      [defaultTheme.breakpoints.between("sm", "md")]: {
+        fontSize: "30px",
+        lineHeight: "44px",
+      },
+      // Underlaptop
+      [defaultTheme.breakpoints.down("md")]: {
+        fontSize: "30px",
+        lineHeight: "44px",
+      },
+      // Laptop
+      [defaultTheme.breakpoints.between("md", "lg")]: {
+        fontSize: "36px",
+      },
+      // Desktop
+      [defaultTheme.breakpoints.between("lg", "xl")]: {
+        fontSize: "36px",
+      },
+      // Above desktop
+      [defaultTheme.breakpoints.up("lg")]: {
+        fontSize: "48px",
+      },
+      // 4K
+      [defaultTheme.breakpoints.up("xl")]: {
+        fontSize: "48px",
+      },
+    },
+    slogan3: {
+      // Default
+      ...designTokens.typography.variants.slogan3,
+      // Mobile
+      [defaultTheme.breakpoints.down("sm")]: {
+        // Use default
+      },
+      // Tablet
+      [defaultTheme.breakpoints.between("sm", "md")]: {
+        fontSize: "15px",
+      },
+      // Underlaptop
+      [defaultTheme.breakpoints.down("md")]: {
+        fontSize: "15px",
+      },
+      // Laptop
+      [defaultTheme.breakpoints.between("md", "lg")]: {
+        fontSize: "16px",
+        lineHeight: "22px",
+      },
+      // Desktop
+      [defaultTheme.breakpoints.between("lg", "xl")]: {
+        fontSize: "16px",
+        lineHeight: "22px",
+      },
+      // Above desktop
+      [defaultTheme.breakpoints.up("lg")]: {
+        fontSize: "16px",
+        lineHeight: "22px",
+      },
+      // 4K
+      [defaultTheme.breakpoints.up("xl")]: {
+        fontSize: "16px",
+        lineHeight: "22px",
+      },
+    },
     heading1: designTokens.typography.variants.heading1,
     heading2: designTokens.typography.variants.heading2,
     heading3: designTokens.typography.variants.heading3,

--- a/src/types/styles/themeRC8Types.ts
+++ b/src/types/styles/themeRC8Types.ts
@@ -64,6 +64,7 @@ declare module "@mui/material/styles" {
   interface TypographyVariants {
     slogan1: React.CSSProperties;
     slogan2: React.CSSProperties;
+    slogan3: React.CSSProperties;
     heading1: React.CSSProperties;
     heading2: React.CSSProperties;
     heading3: React.CSSProperties;
@@ -78,6 +79,7 @@ declare module "@mui/material/styles" {
   interface TypographyVariantsOptions {
     slogan1?: React.CSSProperties;
     slogan2?: React.CSSProperties;
+    slogan3?: React.CSSProperties;
     heading1?: React.CSSProperties;
     heading2?: React.CSSProperties;
     heading3?: React.CSSProperties;
@@ -145,6 +147,7 @@ declare module "@mui/material/Typography/Typography" {
   interface TypographyPropsVariantOverrides {
     slogan1: true;
     slogan2: true;
+    slogan3: true;
     heading1: true;
     heading2: true;
     heading3: true;


### PR DESCRIPTION
Refactor theme to make it responsive avoid use of useBreakpoint() everywhere, the breakpoint is same as what we have now.

## Before
<img width="505" height="370" alt="image" src="https://github.com/user-attachments/assets/a08948fd-c5d7-4a5a-a1b9-85ef5c9eb103" />

## After
<img width="465" height="162" alt="image" src="https://github.com/user-attachments/assets/69ffd697-91ad-4641-9624-b36b8e5a19af" />
