### PR TITLE
rename misc link

### DIFF
--- a/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
+++ b/src/pages/detail-page/subpages/tab-panels/DataAccessPanel.tsx
@@ -125,7 +125,7 @@ const DataAccessPanel: FC<DataAccessPanelProps> = ({ mode, type }) => {
                     ...portalTheme.typography.body1Medium,
                   }}
                 >
-                  {TITLE.has(key) ? TITLE.get(key) : "Misc Link"}
+                  {TITLE.has(key) ? TITLE.get(key) : "Downloadable Link"}
                   {!item || item.length === 0 ? (
                     <NaList title={title ? title : ""} />
                   ) : (


### PR DESCRIPTION
rename `Misc Link` to `Downloadable Link` which sounds more reasonable
<img width="735" height="546" alt="image" src="https://github.com/user-attachments/assets/28fef687-133f-4df4-b3eb-c6682b1393c8" />
