### PR TITLE
:lipstick: update detail page header mobile

### DIFF
--- a/src/assets/icons/details/temporal.tsx
+++ b/src/assets/icons/details/temporal.tsx
@@ -1,0 +1,19 @@
+import { ComponentType, SVGProps } from "react";
+
+export const TemporalIcon: ComponentType<SVGProps<SVGSVGElement>> = ({
+  color = "#595959",
+  width = 20,
+  height = 20,
+}: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill={color}
+      d="M1,3 L9,12 L1,21 L8,21 L16,12 L8,3 Z M10,3 L18,12 L10,21 L17,21 L25,12 L17,3 Z"
+    />
+  </svg>
+);

--- a/src/pages/detail-page/subpages/HeaderSection.tsx
+++ b/src/pages/detail-page/subpages/HeaderSection.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
   Badge,
 } from "@mui/material";
-import DoneAllIcon from "@mui/icons-material/DoneAll";
 import { useDetailPageContext } from "../context/detail-page-context";
 import imosLogoWithTitle from "@/assets/logos/imos_logo_with_title.png";
 import OrganizationLogo from "../../../components/logo/OrganizationLogo";
@@ -38,11 +37,6 @@ import { DataTestId } from "../../../components/map/mapbox/constants";
 import { ReplyIcon } from "../../../assets/icons/details/back";
 import LabelChip from "../../../components/common/label/LabelChip";
 import AIGenStarIcon from "../../../components/icon/AIGenStarIcon";
-
-enum Status {
-  onGoing = "onGoing",
-  completed = "completed",
-}
 
 interface HeaderButtonProps {
   children: ReactNode;
@@ -133,29 +127,9 @@ const renderOnGoingStatus = () => (
   </RoundCard>
 );
 
-const renderCompletedStatus = () => (
-  <RoundCard
-    sx={{
-      border: `${border.xs} ${color.gray.extraLight}`,
-      backgroundColor: color.blue.extraLightSemiTransparent,
-    }}
-  >
-    <DoneAllIcon sx={{ fontSize: "18px" }} color="primary" />
-    <Typography
-      padding={0}
-      paddingX={padding.extraSmall}
-      variant="title1Medium"
-      color={portalTheme.palette.text1}
-    >
-      Completed
-    </Typography>
-  </RoundCard>
-);
-
 const renderSubTitle = (
   startDate: string | undefined,
   endDate: string | undefined,
-  status: string | undefined,
   scope: string | undefined,
   aiUpdateFrequency: string | undefined
 ) => (
@@ -189,11 +163,7 @@ const renderSubTitle = (
         </Typography>
       </RoundCard>
     )}
-    {!startDate &&
-      !endDate &&
-      (status === Status.completed
-        ? renderCompletedStatus()
-        : renderOnGoingStatus())}
+    {!startDate && !endDate && renderOnGoingStatus()}
     {scope && scope.toLowerCase() === "document" && (
       <RoundCard sx={{ backgroundColor: `${color.success.light}` }}>
         <LabelChip
@@ -260,24 +230,22 @@ const HeaderSection = () => {
   const redirectHome = useRedirectHome();
   const redirectSearch = useRedirectSearch();
 
-  const [title, status, startDate, endDate, scope, aiUpdateFrequency] =
-    useMemo(() => {
-      const title = collection?.title;
-      const status = collection?.getStatus();
-      const extent = collection?.getExtent();
-      const scope = collection?.getScope();
-      const aiUpdateFrequency = collection?.getAiUpdateFrequency();
+  const [title, startDate, endDate, scope, aiUpdateFrequency] = useMemo(() => {
+    const title = collection?.title;
+    const extent = collection?.getExtent();
+    const scope = collection?.getScope();
+    const aiUpdateFrequency = collection?.getAiUpdateFrequency();
 
-      let startDate = undefined;
-      let endDate = undefined;
-      if (extent) {
-        const [s, e] = extent.getOverallTemporal();
-        startDate = s;
-        endDate = e;
-      }
+    let startDate = undefined;
+    let endDate = undefined;
+    if (extent) {
+      const [s, e] = extent.getOverallTemporal();
+      startDate = s;
+      endDate = e;
+    }
 
-      return [title, status, startDate, endDate, scope, aiUpdateFrequency];
-    }, [collection]);
+    return [title, startDate, endDate, scope, aiUpdateFrequency];
+  }, [collection]);
 
   // Capture the referer when the detail page first mounts.
   // Tab switching within the detail page won't overwrite this value.
@@ -367,13 +335,7 @@ const HeaderSection = () => {
                 {title}
               </Typography>
               {!isMobile &&
-                renderSubTitle(
-                  startDate,
-                  endDate,
-                  status,
-                  scope,
-                  aiUpdateFrequency
-                )}
+                renderSubTitle(startDate, endDate, scope, aiUpdateFrequency)}
             </Grid>
             <Grid
               item
@@ -398,13 +360,7 @@ const HeaderSection = () => {
             </Grid>
             {isMobile && (
               <Grid item xs={8} sm={12}>
-                {renderSubTitle(
-                  startDate,
-                  endDate,
-                  status,
-                  scope,
-                  aiUpdateFrequency
-                )}
+                {renderSubTitle(startDate, endDate, scope, aiUpdateFrequency)}
               </Grid>
             )}
           </Grid>

--- a/src/pages/detail-page/subpages/HeaderSection.tsx
+++ b/src/pages/detail-page/subpages/HeaderSection.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../styles/constants";
 import ShareButtonMenu from "../../../components/menu/ShareButtonMenu";
 import DataUsageIcon from "@mui/icons-material/DataUsage";
-import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
+import { TemporalIcon } from "../../../assets/icons/details/temporal";
 import { pageReferer } from "../../../components/common/constants";
 import { capitalizeFirstLetter } from "../../../utils/StringUtils";
 import { portalTheme } from "../../../styles";
@@ -160,6 +160,40 @@ const renderSubTitle = (
   aiUpdateFrequency: string | undefined
 ) => (
   <Stack flexDirection="row" flexWrap="wrap" gap={1}>
+    {startDate && (
+      <RoundCard
+        sx={{
+          backgroundColor: "transparent",
+        }}
+      >
+        <Typography
+          padding={0}
+          paddingRight={padding.small}
+          variant="title1Medium"
+          color={portalTheme.palette.text1}
+        >
+          {startDate}
+        </Typography>
+        <TemporalIcon
+          color={color.gray.light}
+          width={fontSize.label}
+          height={fontSize.label}
+        />
+        <Typography
+          padding={0}
+          paddingLeft={padding.small}
+          variant="title1Medium"
+          color={portalTheme.palette.text1}
+        >
+          {endDate ?? "Ongoing"}
+        </Typography>
+      </RoundCard>
+    )}
+    {!startDate &&
+      !endDate &&
+      (status === Status.completed
+        ? renderCompletedStatus()
+        : renderOnGoingStatus())}
     {scope && scope.toLowerCase() === "document" && (
       <RoundCard sx={{ backgroundColor: `${color.success.light}` }}>
         <LabelChip
@@ -216,42 +250,6 @@ const renderSubTitle = (
           </RoundCard>
         </Badge>
       ))}
-    {startDate && (
-      <RoundCard
-        sx={{
-          border: `${border.xs} ${color.gray.extraLight}`,
-          backgroundColor: color.blue.extraLightSemiTransparent,
-        }}
-      >
-        <Typography
-          padding={0}
-          paddingRight={padding.small}
-          variant="title1Medium"
-          color={portalTheme.palette.text1}
-        >
-          {startDate}
-        </Typography>
-        <KeyboardDoubleArrowRightIcon
-          sx={{
-            fontSize: fontSize.label,
-            color: color.gray.light,
-          }}
-        />
-        {endDate && (
-          <Typography
-            padding={0}
-            paddingLeft={padding.small}
-            variant="title1Medium"
-            color={portalTheme.palette.text1}
-          >
-            {endDate}
-          </Typography>
-        )}
-      </RoundCard>
-    )}
-    {status && status === Status.completed
-      ? renderCompletedStatus()
-      : renderOnGoingStatus()}
   </Stack>
 );
 
@@ -364,11 +362,6 @@ const HeaderSection = () => {
                 color={portalTheme.palette.text2}
                 sx={{
                   p: 0,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  display: "-webkit-box",
-                  WebkitLineClamp: "3",
-                  WebkitBoxOrient: "vertical",
                 }}
               >
                 {title}
@@ -396,7 +389,7 @@ const HeaderSection = () => {
                 <OrganizationLogo
                   logo={collection.findIcon()}
                   sx={{
-                    height: isMobile ? "50px" : "80px",
+                    height: isMobile ? "56px" : "80px",
                     paddingX: padding.extraSmall,
                   }}
                   defaultImageSrc={imosLogoWithTitle}


### PR DESCRIPTION
main changes:
1 dataset temporal style
2 no more "completed" status label
3 display full title in header

<img width="1739" height="943" alt="image" src="https://github.com/user-attachments/assets/3930f607-fc63-4eb5-aa2e-7d05fcabce8f" />

<img width="1684" height="925" alt="image" src="https://github.com/user-attachments/assets/47db8b29-7334-475d-b09d-2908a97a7307" />

