### PR TITLE
Fix filter missing time cause ogcapi error

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,6 +1,6 @@
 const dateDefault = {
-  // Must use this format to do search, we do not care about the time
-  DATE_TIME_FORMAT: "YYYY-MM-DDT00:00:00[Z]",
+  // Must use this format to do search, we care about the time
+  DATE_TIME_FORMAT: "YYYY-MM-DDTHH:mm:ss[Z]",
   DATE_FORMAT: "YYYY-MM-DD",
   DATE_YEAR_MONTH_FORMAT: "YYYY-MM",
   DISPLAY_FORMAT: "DD/MM/YYYY",

--- a/src/components/common/store/__test__/searchReducer.test.tsx
+++ b/src/components/common/store/__test__/searchReducer.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import default_thumbnail from "@/assets/images/default-thumbnail.png";
 import { OGCCollection } from "../OGCCollectionDefinitions";
-import { ParameterState } from "../componentParamReducer";
+import { DateTimeFilterRange, ParameterState } from "../componentParamReducer";
 import { createSearchParamFrom, SearchParameters } from "../searchReducer";
+import dayjs from "dayjs";
 
 describe("Search Reducer Function Test", () => {
   it("Empty links return default thumbnail", () => {
@@ -93,6 +94,22 @@ describe("Search Reducer Function Test", () => {
     // Verify they are wrapped in parentheses as OR condition
     expect(result.filter).toContain(
       "(assets_summary IS NOT NULL) OR links_airole_contains='download'"
+    );
+  });
+  // We need to make sure time is aware otherwise OGC api will throw exception where start = end exactly
+  it("should include time in dateRange, start is 00:00:00 end is 23:59:59", () => {
+    const param: ParameterState = {
+      dateTimeFilterRange: {
+        start: dayjs("2025-05-07T00:00:00").valueOf(),
+        end: dayjs("2025-05-07T23:59:59").valueOf(),
+      } as DateTimeFilterRange,
+    };
+
+    const result = createSearchParamFrom(param);
+
+    // Verify both CO data and download link filters are included with OR
+    expect(result.filter).toContain(
+      "temporal DURING 2025-05-07T00:00:00Z/2025-05-07T23:59:59Z"
     );
   });
 });


### PR DESCRIPTION
This fix is make sure the time is pass on the query, before change only date part is set and time part all zero which cause a problem with end data if you set the start date = end date.

After the fix the time part will pass together align with the end date value which is usually 23:59:59