### PR TITLE
Bugfix/8376 word missing in chips

### DIFF
--- a/src/components/layout/__test__/Header.test.tsx
+++ b/src/components/layout/__test__/Header.test.tsx
@@ -14,7 +14,10 @@ import { ThemeProvider } from "@mui/material/styles";
 import { MemoryRouter } from "react-router-dom";
 import AppTheme from "../../../utils/AppTheme";
 import store from "../../common/store/store";
-import { clearComponentParam } from "../../common/store/componentParamReducer";
+import {
+  clearComponentParam,
+  updateHasData,
+} from "../../common/store/componentParamReducer";
 import Header from "../components/Header";
 import { SEARCHBAR_EXPANSION_WIDTH_LAPTOP } from "../../search/constants";
 
@@ -98,5 +101,33 @@ describe("Header Searchbar Expansion", () => {
     searchInput.blur();
 
     expect(searchWrapper).toHaveStyle({ minWidth: expectedLaptopWidth });
+  });
+
+  it("should hide the filter chips divider when there is no filter set, and show it when a filter is set", async () => {
+    const { container } = render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <MemoryRouter initialEntries={["/search"]}>
+            <Header />
+          </MemoryRouter>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    // 1. Initial State: No filters are set, so there should be no horizontal divider (hr element) inside the layout
+    const dividers = container.querySelectorAll("hr");
+    expect(dividers.length).toBe(0);
+
+    // 2. Set a filter (e.g. updateHasData(true))
+    const { act } = await import("@testing-library/react");
+    act(() => {
+      store.dispatch(updateHasData(true));
+    });
+
+    // 3. Now the divider (<hr>) should be rendered!
+    await waitFor(() => {
+      const updatedDividers = container.querySelectorAll("hr");
+      expect(updatedDividers.length).toBe(1);
+    });
   });
 });

--- a/src/components/layout/components/Header.tsx
+++ b/src/components/layout/components/Header.tsx
@@ -15,6 +15,8 @@ import SectionContainer from "./SectionContainer";
 import HeaderMenu, { HeaderMenuStyle } from "./HeaderMenu";
 import { pageDefault } from "../../common/constants";
 import Searchbar from "../../search/Searchbar";
+import { useAppSelector } from "../../common/store/hooks";
+import { ParameterState } from "../../common/store/componentParamReducer";
 import {
   PAGE_CONTENT_MAX_WIDTH,
   PAGE_CONTENT_WIDTH_HEADER,
@@ -47,6 +49,19 @@ const Header: FC = () => {
   const [chipsContainer, setChipsContainer] = useState<HTMLDivElement | null>(
     null
   );
+
+  const params = useAppSelector((state) => state.paramReducer);
+
+  const hasActiveFilters =
+    !!(params.dateTimeFilterRange?.start || params.dateTimeFilterRange?.end) ||
+    !!params.polygon ||
+    !!(params.staticAreas && params.staticAreas.length > 0) ||
+    !!params.datasetGroup ||
+    !!(params.parameterVocabs && params.parameterVocabs.length > 0) ||
+    !!(params.platform && params.platform.length > 0) ||
+    !!params.updateFreq ||
+    !!params.datasetStatus ||
+    !!params.hasCOData;
 
   return (
     <Box
@@ -175,7 +190,7 @@ const Header: FC = () => {
       Row 2: Active Filters Chips perfectly aligned under the Searchbar.
       topDividerStyle={{ marginTop: "0" }}, makes the divider visible
       */}
-      {isSearchResultPage && !isMobile && (
+      {isSearchResultPage && !isMobile && hasActiveFilters && (
         <SectionContainer
           topDividerStyle={{ marginTop: undefined }}
           contentAreaStyle={{

--- a/src/components/search/ActiveFiltersChips.tsx
+++ b/src/components/search/ActiveFiltersChips.tsx
@@ -111,7 +111,9 @@ const ActiveFiltersChips: FC = () => {
             dispatch(
               updateFilterStaticAreas(
                 params.staticAreas!.filter(
-                  (a) => a.boundaryName !== area.boundaryName
+                  (a) =>
+                    a.boundaryName !== area.boundaryName ||
+                    String(a.value) !== String(area.value)
                 )
               )
             ),

--- a/src/components/search/ActiveFiltersChips.tsx
+++ b/src/components/search/ActiveFiltersChips.tsx
@@ -87,17 +87,20 @@ const ActiveFiltersChips: FC = () => {
         switch (area.boundaryName) {
           case BoundaryName.MEOW:
             return (
-              marineEcoregion.find((opt) => opt.value === area.value)?.label ||
-              ""
+              marineEcoregion.find(
+                (opt) => String(opt.value) === String(area.value)
+              )?.label || ""
             );
           case BoundaryName.AUSTRALIAN_MARINE_PARKS:
             return (
-              marinePark.find((opt) => opt.value === area.value)?.label || ""
+              marinePark.find((opt) => String(opt.value) === String(area.value))
+                ?.label || ""
             );
           case BoundaryName.CORAL_ATLAS:
             return (
-              allenCoralAtlas.find((opt) => opt.value === area.value)?.label ||
-              ""
+              allenCoralAtlas.find(
+                (opt) => String(opt.value) === String(area.value)
+              )?.label || ""
             );
         }
       };

--- a/src/components/search/ActiveFiltersChips.tsx
+++ b/src/components/search/ActiveFiltersChips.tsx
@@ -16,7 +16,8 @@ import {
   updateUpdateFreq,
 } from "../common/store/componentParamReducer";
 import dayjs from "dayjs";
-import { dateDefault } from "../common/constants";
+import { dateDefault, pageReferer } from "../common/constants";
+import useRedirectSearch from "../../hooks/useRedirectSearch";
 import { borderRadius, color } from "../../styles/constants";
 import { TrashIcon } from "../../assets/icons/search/trash";
 import {
@@ -30,6 +31,7 @@ import { DATA_SETTINGS } from "../filter/tab-filters/DataSettingsFilter";
 
 const ActiveFiltersChips: FC = () => {
   const dispatch = useAppDispatch();
+  const redirectSearch = useRedirectSearch();
   const theme = useTheme();
   const params = useAppSelector((state) => state.paramReducer);
 
@@ -50,7 +52,8 @@ const ActiveFiltersChips: FC = () => {
 
   const handleClearAll = useCallback(() => {
     dispatch(clearComponentParam());
-  }, [dispatch]);
+    redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+  }, [dispatch, redirectSearch]);
 
   const activeFilters = useMemo(() => {
     const chips: Array<{ label: string; onDelete: () => void }> = [];
@@ -69,7 +72,10 @@ const ActiveFiltersChips: FC = () => {
         : "...";
       chips.push({
         label: `Date: ${start} - ${end}`,
-        onDelete: () => dispatch(updateDateTimeFilterRange({})),
+        onDelete: () => {
+          dispatch(updateDateTimeFilterRange({}));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
@@ -77,7 +83,10 @@ const ActiveFiltersChips: FC = () => {
     if (params.polygon) {
       chips.push({
         label: "Spatial Filter",
-        onDelete: () => dispatch(updateFilterPolygon(undefined)),
+        onDelete: () => {
+          dispatch(updateFilterPolygon(undefined));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
@@ -107,7 +116,7 @@ const ActiveFiltersChips: FC = () => {
       params.staticAreas.forEach((area) => {
         chips.push({
           label: `Area: ${getLabel(area)} (${area.boundaryName})`,
-          onDelete: () =>
+          onDelete: () => {
             dispatch(
               updateFilterStaticAreas(
                 params.staticAreas!.filter(
@@ -116,7 +125,9 @@ const ActiveFiltersChips: FC = () => {
                     String(a.value) !== String(area.value)
                 )
               )
-            ),
+            );
+            redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+          },
         });
       });
     }
@@ -125,7 +136,10 @@ const ActiveFiltersChips: FC = () => {
     if (params.datasetGroup) {
       chips.push({
         label: `Group: ${params.datasetGroup}`,
-        onDelete: () => dispatch(updateDatasetGroup(undefined)),
+        onDelete: () => {
+          dispatch(updateDatasetGroup(undefined));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
@@ -134,12 +148,14 @@ const ActiveFiltersChips: FC = () => {
       params.parameterVocabs.forEach((vocab) => {
         chips.push({
           label: vocab.label,
-          onDelete: () =>
+          onDelete: () => {
             dispatch(
               updateParameterVocabs(
                 params.parameterVocabs!.filter((v) => v.label !== vocab.label)
               )
-            ),
+            );
+            redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+          },
         });
       });
     }
@@ -149,10 +165,12 @@ const ActiveFiltersChips: FC = () => {
       params.platform.forEach((p) => {
         chips.push({
           label: `Platform: ${p}`,
-          onDelete: () =>
+          onDelete: () => {
             dispatch(
               updatePlatform(params.platform!.filter((item) => item !== p))
-            ),
+            );
+            redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+          },
         });
       });
     }
@@ -161,7 +179,10 @@ const ActiveFiltersChips: FC = () => {
     if (params.updateFreq) {
       chips.push({
         label: `Delivery Mode: ${DATA_SETTINGS.dataDeliveryFrequency.find((f) => f.value === params.updateFreq)?.label || params.updateFreq}`,
-        onDelete: () => dispatch(updateUpdateFreq(undefined)),
+        onDelete: () => {
+          dispatch(updateUpdateFreq(undefined));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
@@ -169,7 +190,10 @@ const ActiveFiltersChips: FC = () => {
     if (params.datasetStatus) {
       chips.push({
         label: `Status: ${DATA_SETTINGS.dataStatus.find((f) => f.value === params.datasetStatus)?.label || params.datasetStatus}`,
-        onDelete: () => dispatch(updateStatus(undefined)),
+        onDelete: () => {
+          dispatch(updateStatus(undefined));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
@@ -177,12 +201,22 @@ const ActiveFiltersChips: FC = () => {
     if (params.hasCOData) {
       chips.push({
         label: "Cloud Optimized",
-        onDelete: () => dispatch(updateHasData(false)),
+        onDelete: () => {
+          dispatch(updateHasData(false));
+          redirectSearch(pageReferer.COMPONENT_COMPLEX_TEXT_REFERER);
+        },
       });
     }
 
     return chips;
-  }, [params, dispatch, marineEcoregion, marinePark, allenCoralAtlas]);
+  }, [
+    params,
+    dispatch,
+    redirectSearch,
+    marineEcoregion,
+    marinePark,
+    allenCoralAtlas,
+  ]);
 
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);

--- a/src/components/search/__test__/Searchbar.test.tsx
+++ b/src/components/search/__test__/Searchbar.test.tsx
@@ -57,6 +57,7 @@ vi.mock(import("react-router-dom"), async (importOriginal) => {
 });
 
 import { BrowserRouter as Router } from "react-router-dom";
+import * as useRedirectSearchModule from "../../../hooks/useRedirectSearch";
 import Searchbar from "../Searchbar";
 import { PARAMETER_VOCABS } from "../../../__mocks__/data/PARAMETER_VOCABS";
 import { encodeParam } from "../../../utils/UrlUtils";
@@ -389,5 +390,40 @@ describe("Searchbar", () => {
         screen.getByText("Area: Beagle Marine Park (AMP)")
       ).toBeInTheDocument();
     });
+  });
+
+  it("should trigger a search redirect when a chip is deleted", async () => {
+    const user = userEvent.setup();
+    const redirectSearchSpy = vi.fn();
+    vi.spyOn(useRedirectSearchModule, "default").mockReturnValue(
+      redirectSearchSpy
+    );
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router>
+            <Searchbar />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    // Dispatch some state, e.g. Cloud Optimized filter (hasCOData)
+    store.dispatch(updateHasData(true));
+
+    // Wait for the chip to render
+    await waitFor(() => {
+      expect(screen.getByText("Cloud Optimized")).toBeInTheDocument();
+    });
+
+    // Find and click the delete button for the Cloud Optimized chip
+    const chip = screen.getByText("Cloud Optimized").closest(".MuiChip-root");
+    expect(chip).toBeInTheDocument();
+    const deleteButton = within(chip!).getByTestId("CloseIcon");
+    await user.click(deleteButton);
+
+    // Verify redirectSearch was invoked!
+    expect(redirectSearchSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/search/__test__/Searchbar.test.tsx
+++ b/src/components/search/__test__/Searchbar.test.tsx
@@ -376,9 +376,9 @@ describe("Searchbar", () => {
     // Find and click the delete button for "Apollo Marine Park"
     const apolloChip = screen
       .getByText("Area: Apollo Marine Park (AMP)")
-      .closest(".MuiChip-root");
+      .closest(".MuiChip-root") as HTMLElement;
     expect(apolloChip).toBeInTheDocument();
-    const deleteButton = within(apolloChip!).getByTestId("CloseIcon");
+    const deleteButton = within(apolloChip).getByTestId("CloseIcon");
     await user.click(deleteButton);
 
     // Apollo Marine Park should be gone, but Beagle Marine Park should remain!
@@ -418,9 +418,11 @@ describe("Searchbar", () => {
     });
 
     // Find and click the delete button for the Cloud Optimized chip
-    const chip = screen.getByText("Cloud Optimized").closest(".MuiChip-root");
+    const chip = screen
+      .getByText("Cloud Optimized")
+      .closest(".MuiChip-root") as HTMLElement;
     expect(chip).toBeInTheDocument();
-    const deleteButton = within(chip!).getByTestId("CloseIcon");
+    const deleteButton = within(chip).getByTestId("CloseIcon");
     await user.click(deleteButton);
 
     // Verify redirectSearch was invoked!

--- a/src/components/search/__test__/Searchbar.test.tsx
+++ b/src/components/search/__test__/Searchbar.test.tsx
@@ -322,4 +322,72 @@ describe("Searchbar", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("should only delete the clicked chip when multiple static areas of the same boundary type are active", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetchMarineParkOptions).mockResolvedValue([
+      {
+        boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+        label: "Apollo Marine Park",
+        value: "3",
+      },
+      {
+        boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+        label: "Beagle Marine Park",
+        value: "4",
+      },
+    ]);
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router>
+            <Searchbar />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    store.dispatch(
+      updateFilterStaticAreas([
+        {
+          boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+          value: "3",
+        },
+        {
+          boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+          value: "4",
+        },
+      ])
+    );
+
+    // Wait for both chips to be rendered
+    await waitFor(() => {
+      expect(
+        screen.getByText("Area: Apollo Marine Park (AMP)")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Area: Beagle Marine Park (AMP)")
+      ).toBeInTheDocument();
+    });
+
+    // Find and click the delete button for "Apollo Marine Park"
+    const apolloChip = screen
+      .getByText("Area: Apollo Marine Park (AMP)")
+      .closest(".MuiChip-root");
+    expect(apolloChip).toBeInTheDocument();
+    const deleteButton = within(apolloChip!).getByTestId("CloseIcon");
+    await user.click(deleteButton);
+
+    // Apollo Marine Park should be gone, but Beagle Marine Park should remain!
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Area: Apollo Marine Park (AMP)")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Area: Beagle Marine Park (AMP)")
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/search/__test__/Searchbar.test.tsx
+++ b/src/components/search/__test__/Searchbar.test.tsx
@@ -16,7 +16,12 @@ import {
   updateParameterVocabs,
   updatePlatform,
   updateUpdateFreq,
+  updateFilterStaticAreas,
 } from "../../common/store/componentParamReducer";
+import {
+  fetchMarineParkOptions,
+  BoundaryName,
+} from "../../map/mapbox/layers/StaticLayer";
 import { server } from "../../../__mocks__/server";
 import { ThemeProvider } from "@mui/material/styles";
 import AppTheme from "../../../utils/AppTheme";
@@ -278,6 +283,43 @@ describe("Searchbar", () => {
       // Verify numeric values
       expect(paramReducer.zoom).toBe(3.5);
       expect(typeof paramReducer.zoom).toBe("number");
+    });
+  });
+
+  it("should render active filter chips with correct labels even when loaded from URL parameters (which parses ID to number)", async () => {
+    vi.mocked(fetchMarineParkOptions).mockResolvedValue([
+      {
+        boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+        label: "Apollo Marine Park",
+        value: "3",
+      },
+    ]);
+
+    render(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router>
+            <Searchbar />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+
+    // Mock staticAreas where value is parsed as a number (3) instead of string ("3")
+    store.dispatch(
+      updateFilterStaticAreas([
+        {
+          boundaryName: BoundaryName.AUSTRALIAN_MARINE_PARKS,
+          value: 3 as any,
+        },
+      ])
+    );
+
+    // Wait for the chip to be rendered with the correct label
+    await waitFor(() => {
+      expect(
+        screen.getByText("Area: Apollo Marine Park (AMP)")
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
1. The bug happens because when parse the URL param, it think the id is a number but the lookup from the chip assume it is string, the cause the compare failed and show empty.
2. It now show hide the divider by checking filter is empty or not.
3. Update chip delete action so it refresh search and update URL