### PR TITLE
:bug: fix navigation bar observers

### DIFF
--- a/src/pages/detail-page/layout/NavigatablePanel.tsx
+++ b/src/pages/detail-page/layout/NavigatablePanel.tsx
@@ -3,7 +3,7 @@ import React, {
   FC,
   ReactNode,
   useCallback,
-  useLayoutEffect,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -40,7 +40,7 @@ const VerticalIndicator: FC<VerticalIndicatorProps> = ({
   const [metrics, setMetrics] = useState({ totalHeight: 0, activeY: 0 });
   const theme = useTheme();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const updateMetrics = () => {
       let totalHeight = 0;
       let activeY = 0;


### PR DESCRIPTION
Use useEffect (not useLayoutEffect): 
- refs for the sibling DetailSubtabBtn list are attached AFTER VerticalIndicator's commit-time effects
- so a useLayoutEffect here sees `menuRefs[i].current === null` and never wires up the two observers `ResizeObserver`/`IntersectionObserver`
- useEffect runs after the full tree commits and paint, when every ref is populated.