### PR TITLE
Playwright: unskip test

### DIFF
--- a/playwright/tests/search_page/api/test_request_urls.py
+++ b/playwright/tests/search_page/api/test_request_urls.py
@@ -140,9 +140,6 @@ def test_search_api_request_urls_across_page(
         )
     ],
 )
-@pytest.mark.skip(
-    reason='Ignoring for now due to search reducer updated, which requires updating the test assertions accordingly.'
-)
 def test_search_api_request_urls_after_map_state_change(
     responsive_page: Page,
     date: str,


### PR DESCRIPTION
The Playwright test `test_search_api_request_urls_after_map_state_change` was skipped in PR #839 (see issue #842) due to an failure in CI. The failure was associated to search reducer updates that changed how `parameter_vocabs`, `platform_vocabs` and `ai_update_frequency` filters are queried.

After reviewing the test logic and the described search reducer changes, the test does not rely on the full request URL for its assertions. The test intercepts API calls using a wildcard base path (`/collections?properties=...&*`) and then asserts on specific query parameter values. The reducer changes only *add* new filter fields (`ai_parameter_vocabs`, `ai_platform_vocabs`, `ai_update_frequency`) without altering the existing `parameter_vocabs` and `platform_vocabs` query structure that the test validates.

The test probably failed due to an isolated timeout issue rather than a functional regression caused by the frontend updates. So, the skip marking is removed for this test and it is ran multiple times both locally and in CI to ensure it's stable.