### PR TITLE
8535-update-google-index

### DIFF
--- a/public/robots.nonprod.txt
+++ b/public/robots.nonprod.txt
@@ -1,3 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
+# Allow crawling so Googlebot can read the <meta name="robots" content="noindex">
+# tag and drop non-prod pages from its index. Do NOT use "Disallow: /" here — a
+# blocked page can never be de-indexed because Google can't fetch the noindex tag.
 User-agent: *
-Disallow: /
+Allow: /

--- a/src/utils/AppRouter.tsx
+++ b/src/utils/AppRouter.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from "./ErrorBoundary";
 import { pageDefault } from "../components/common/constants";
 import HealthChecker from "./HealthChecker";
 import DegradedPage from "../pages/error-page/DegradedPage";
+import { syncCanonicalUrl } from "./seo/canonicalUrl";
 import React from "react";
 
 // Helper to conditionally wrap a page with HealthChecker based on the mode
@@ -70,6 +71,9 @@ const router = createBrowserRouter([
     children: [],
   },
 ]);
+
+// Keep the canonical URL in sync with the current route (SEO).
+syncCanonicalUrl(router);
 
 export default router;
 // TODO: move this to different place that is more related

--- a/src/utils/seo/__test__/canonicalUrl.test.ts
+++ b/src/utils/seo/__test__/canonicalUrl.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { createMemoryRouter } from "react-router-dom";
+import { syncCanonicalUrl } from "../canonicalUrl";
+
+const canonicalHref = () =>
+  document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href;
+
+const canonicalCount = () =>
+  document.head.querySelectorAll('link[rel="canonical"]').length;
+
+const buildRouter = (initialPath: string) =>
+  createMemoryRouter(
+    [{ path: "/" }, { path: "/search" }, { path: "/details/:uuid" }],
+    { initialEntries: [initialPath] }
+  );
+
+describe("syncCanonicalUrl", () => {
+  beforeEach(() => {
+    document.head.querySelector('link[rel="canonical"]')?.remove();
+  });
+
+  test("sets the canonical to the prod URL for the initial route", () => {
+    syncCanonicalUrl(buildRouter("/details/abc-123"));
+
+    expect(canonicalHref()).toBe("https://portal.aodn.org.au/details/abc-123");
+  });
+
+  test("creates the <link rel=canonical> element when the page has none", () => {
+    expect(canonicalCount()).toBe(0);
+
+    syncCanonicalUrl(buildRouter("/"));
+
+    expect(canonicalCount()).toBe(1);
+    expect(canonicalHref()).toBe("https://portal.aodn.org.au/");
+  });
+
+  test("reuses the existing canonical element instead of adding another", () => {
+    const existing = document.createElement("link");
+    existing.rel = "canonical";
+    document.head.appendChild(existing);
+
+    syncCanonicalUrl(buildRouter("/search"));
+
+    expect(canonicalCount()).toBe(1);
+    expect(canonicalHref()).toBe("https://portal.aodn.org.au/search");
+  });
+
+  test("updates the canonical when the route changes", async () => {
+    const router = buildRouter("/");
+    syncCanonicalUrl(router);
+    expect(canonicalHref()).toBe("https://portal.aodn.org.au/");
+
+    await router.navigate("/details/xyz");
+
+    expect(canonicalHref()).toBe("https://portal.aodn.org.au/details/xyz");
+  });
+});

--- a/src/utils/seo/canonicalUrl.ts
+++ b/src/utils/seo/canonicalUrl.ts
@@ -1,0 +1,22 @@
+import type { createBrowserRouter } from "react-router-dom";
+
+type Router = ReturnType<typeof createBrowserRouter>;
+
+const CANONICAL_BASE_URL = "https://portal.aodn.org.au";
+
+const setCanonicalUrl = (pathname: string) => {
+  let link = document.head.querySelector<HTMLLinkElement>(
+    'link[rel="canonical"]'
+  );
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "canonical";
+    document.head.appendChild(link);
+  }
+  link.href = `${CANONICAL_BASE_URL}${pathname}`;
+};
+
+export const syncCanonicalUrl = (router: Router) => {
+  setCanonicalUrl(router.state.location.pathname);
+  router.subscribe((state) => setCanonicalUrl(state.location.pathname));
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,15 +67,13 @@ export default ({ mode }) => {
   const inlineSEOPlugin = () => {
     return {
       name: "inline-seo",
-      transformIndexHtml(html) {
-        const canonicalUrl = "https://portal-beta.aodn.org.au/";
+      transformIndexHtml(html: string) {
         const isProduction = mode === "prod";
 
+        // Canonical is set at runtime per route in AppRouter.tsx (SPA has a single
+        // index.html, so a static canonical would wrongly point every page at "/").
         const seoTags = `
         <!-- SEO -->
-
-        <!-- Canonical URL: All environments point to production for SEO consolidation -->
-        <link rel="canonical" href="${canonicalUrl}" />
 
         ${
           !isProduction


### PR DESCRIPTION
## Status: Code done ✅ — waiting on launch + Google re-crawl ⏳

### What's done (FE)
- **Per-route canonical URLs** — each page now has its own canonical, so Google indexes every page (search, details), not just the homepage.
- **Non-prod robots → `Allow`** — temporary, so Googlebot can read the `noindex` tag and drop beta pages from the index.

### What we're waiting for
1. **Prod launch** — changes only take effect once the new portal goes live on `portal.aodn.org.au` (deployed with `--mode prod`).
2. **Google re-crawl** — after launch, Google re-crawls automatically (days–weeks): beta drops out, prod gets indexed.

### Post-launch follow-up ⚠️
- Once beta has fully dropped out of Google's index, **revert non-prod robots back to `Disallow: /`** to stop crawling beta.
- ⚠️ Do this **only after** beta is gone — reverting too early leaves beta stuck in the index (Google can't read `noindex` if crawling is blocked).

### Known limitation
- Canonical lets detail pages *be* indexed, but Google still has to crawl to each one. Indexing **all** dataset detail pages faster would need a dynamic sitemap (not done yet — future work).