### PR TITLE
Feature/8070 add document filter

### DIFF
--- a/src/components/common/cqlFilters.tsx
+++ b/src/components/common/cqlFilters.tsx
@@ -29,6 +29,7 @@ export type UpdateFrequency = SingleArgumentFunction<DatasetFrequency, string>;
 export type DatasetGroup = SingleArgumentFunction<string, string>;
 export type PlatformFilter = SingleArgumentFunction<Array<string>, string>;
 export type Status = SingleArgumentFunction<DatasetStatus, string>;
+export type ExcludeDatasetScope = SingleArgumentFunction<string, string>;
 export type StaticAreasFilter = SingleArgumentFunction<
   Array<SelectedStaticArea>,
   string
@@ -43,6 +44,7 @@ export type FilterTypes =
   | UpdateFrequency
   | PlatformFilter
   | Status
+  | ExcludeDatasetScope
   | StaticAreasFilter
   | IsNotNull;
 
@@ -58,6 +60,9 @@ const funcUpdateFrequency: UpdateFrequency = (freq: DatasetFrequency) => {
 };
 
 const funcStatus: Status = (stat: DatasetStatus) => `status='${stat}'`;
+
+const funcExcludeDatasetScope: ExcludeDatasetScope = (scope: string) =>
+  `NOT (scope='${scope}')`;
 
 const funcUpdateDatasetGroup: DatasetGroup = (name: string) =>
   `dataset_group='${name}'`;
@@ -145,6 +150,7 @@ cqlDefaultFilters
   .set("BBOX_POLYGON_OR_EMPTY_EXTENTS", funcBBoxPolygonOrEmptyExtents)
   .set("UPDATE_FREQUENCY", funcUpdateFrequency)
   .set("STATUS", funcStatus)
+  .set("EXCLUDE_DATASET_SCOPE", funcExcludeDatasetScope)
   .set("UPDATE_PLATFORM_FILTER_VARIABLES", funcPlatformFilter)
   .set("STATIC_AREAS", funcStaticAreas)
   .set("IS_NOT_NULL", funcIsNotNull);

--- a/src/components/common/store/__test__/componentParamReducer.test.tsx
+++ b/src/components/common/store/__test__/componentParamReducer.test.tsx
@@ -108,6 +108,7 @@ describe("Component Reducer Function Test", () => {
     const sample1: ParameterState = {
       datasetGroup: SearchKeys.IMOS,
       hasCOData: false,
+      excludeDocument: false,
       dateTimeFilterRange: {},
       searchText: "",
       zoom: MapDefaultConfig.ZOOM,
@@ -121,6 +122,7 @@ describe("Component Reducer Function Test", () => {
     const sample4: ParameterState = {
       datasetGroup: SearchKeys.IMOS,
       hasCOData: false,
+      excludeDocument: false,
       dateTimeFilterRange: {
         start: 12345,
         end: 45697,
@@ -144,6 +146,7 @@ describe("Component Reducer Function Test", () => {
     const sample5: ParameterState = {
       datasetGroup: SearchKeys.IMOS,
       hasCOData: false,
+      excludeDocument: false,
       dateTimeFilterRange: {
         start: 12345,
         end: 45697,
@@ -170,6 +173,7 @@ describe("Component Reducer Function Test", () => {
     const sample6: ParameterState = {
       datasetGroup: SearchKeys.IMOS,
       hasCOData: false,
+      excludeDocument: false,
       dateTimeFilterRange: {},
       searchText: "",
       zoom: MapDefaultConfig.ZOOM,

--- a/src/components/common/store/__test__/searchReducer.test.tsx
+++ b/src/components/common/store/__test__/searchReducer.test.tsx
@@ -93,6 +93,16 @@ describe("Search Reducer Function Test", () => {
     );
   });
 
+  it("should exclude document scope when excludeDocument is true", () => {
+    const param: ParameterState = {
+      excludeDocument: true,
+    };
+
+    const result = createSearchParamFrom(param);
+
+    expect(result.filter).toEqual("NOT (scope='document')");
+  });
+
   it("should include both assets_summary and links_airole_contains filter when hasCOData is true", () => {
     const param: ParameterState = {
       hasCOData: true,

--- a/src/components/common/store/componentParamReducer.tsx
+++ b/src/components/common/store/componentParamReducer.tsx
@@ -26,6 +26,7 @@ const UPDATE_SORT_BY_VARIABLE = "UPDATE_SORT_BY_VARIABLE";
 const UPDATE_ZOOM_VARIABLE = "UPDATE_ZOOM_VARIABLE";
 // Contains cloud optimized data where download possible
 const UPDATE_HAS_DATA = "UPDATE_HAS_DATA";
+const UPDATE_EXCLUDE_DOCUMENT = "UPDATE_EXCLUDE_DOCUMENT";
 const UPDATE_SORT = "UPDATE_SORT";
 const UPDATE_LAYOUT = "UPDATE_LAYOUT";
 const UPDATE_STATIC_AREAS_FILTER_VARIABLE =
@@ -73,6 +74,7 @@ export interface ParameterState {
   // User filter using static map areas
   staticAreas?: Array<SelectedStaticArea>;
   hasCOData?: boolean;
+  excludeDocument?: boolean;
   includeNoGeometry?: boolean;
   searchText?: string;
   parameterVocabs?: Array<Vocab>;
@@ -181,6 +183,17 @@ const updateHasData = (hasCOData: boolean | undefined): ActionType => {
   };
 };
 
+const updateExcludeDocument = (
+  excludeDocument: boolean | undefined
+): ActionType => {
+  return {
+    type: UPDATE_EXCLUDE_DOCUMENT,
+    payload: {
+      excludeDocument: excludeDocument,
+    } as ParameterState,
+  };
+};
+
 const updateParameterVocabs = (input: Array<Vocab>): ActionType => {
   // We only need to store label, the other is not needed and will create a massive
   // url.
@@ -272,6 +285,7 @@ const createInitialParameterState = (
   const state: ParameterState = {
     datasetGroup: undefined,
     hasCOData: false,
+    excludeDocument: false,
     dateTimeFilterRange: {},
     searchText: "",
     zoom: MapDefaultConfig.ZOOM,
@@ -312,6 +326,11 @@ const paramReducer = (
       return {
         ...state,
         hasCOData: action.payload.hasCOData,
+      };
+    case UPDATE_EXCLUDE_DOCUMENT:
+      return {
+        ...state,
+        excludeDocument: action.payload.excludeDocument,
       };
     case UPDATE_PLATFORM_FILTER_VARIABLE:
       return {
@@ -525,6 +544,7 @@ export {
   updateStatus,
   updateZoom,
   updateHasData,
+  updateExcludeDocument,
   updateSort,
   updateLayout,
   updateFilterStaticAreas,

--- a/src/components/common/store/searchReducer.tsx
+++ b/src/components/common/store/searchReducer.tsx
@@ -14,6 +14,7 @@ import {
   UpdateFrequency,
   Status,
   StaticAreasFilter,
+  ExcludeDatasetScope,
 } from "../cqlFilters";
 import { OGCCollection, OGCCollections } from "./OGCCollectionDefinitions";
 import {
@@ -672,6 +673,13 @@ const createSearchParamFrom = (
       p.filter,
       `(${coDataFilter} OR ${downloadLinkFilter})`
     );
+  }
+
+  if (i.excludeDocument) {
+    const f = cqlDefaultFilters.get(
+      "EXCLUDE_DATASET_SCOPE"
+    ) as ExcludeDatasetScope;
+    p.filter = appendFilter(p.filter, f("document"));
   }
 
   if (i.updateFreq) {

--- a/src/components/filter/Filters.tsx
+++ b/src/components/filter/Filters.tsx
@@ -35,6 +35,7 @@ interface Filters {
   dataDeliveryMode?: Array<string>;
   dataStatus?: Array<DatasetStatus> | undefined;
   dataIndexedType?: Array<IndexDataType>;
+  excludeDocument?: Array<string>;
   dataService?: Array<string>;
 }
 
@@ -65,6 +66,7 @@ const checkBadge = (filters: Filters, tabName: FiltersTabs): boolean => {
         filters.dataDeliveryMode?.length ||
         filters.dataService?.length ||
         filters.dataIndexedType?.length ||
+        filters.excludeDocument?.length ||
         filters.dataStatus?.length
       );
 
@@ -80,6 +82,7 @@ const FiltersFC: FC<FiltersProps> = ({ sx }) => {
     updateFreq,
     datasetGroup,
     hasCOData,
+    excludeDocument,
     datasetStatus,
   } = useAppSelector((state) => state.paramReducer);
 
@@ -168,6 +171,10 @@ const FiltersFC: FC<FiltersProps> = ({ sx }) => {
           dataIndexedType: [IndexDataType.CLOUD],
         }));
       }
+      setFilters((prevFilters) => ({
+        ...prevFilters,
+        excludeDocument: excludeDocument ? ["Yes"] : undefined,
+      }));
       if (datasetStatus) {
         setFilters((prevFilters) => ({
           ...prevFilters,
@@ -181,6 +188,7 @@ const FiltersFC: FC<FiltersProps> = ({ sx }) => {
     parameterVocabs,
     platform,
     updateFreq,
+    excludeDocument,
     datasetStatus,
   ]);
 

--- a/src/components/filter/tab-filters/DataSettingsFilter.tsx
+++ b/src/components/filter/tab-filters/DataSettingsFilter.tsx
@@ -298,7 +298,7 @@ const DataSettingsFilter: FC<DataSettingsFilterProps> = ({
             padding: "8px 20px",
           }}
         >
-          Exclude Document
+          Exclude Documents
         </Typography>
         <StyledToggleButtonGroup
           value={filters.excludeDocument}

--- a/src/components/filter/tab-filters/DataSettingsFilter.tsx
+++ b/src/components/filter/tab-filters/DataSettingsFilter.tsx
@@ -326,7 +326,7 @@ const DataSettingsFilter: FC<DataSettingsFilterProps> = ({
             <StyledToggleButton
               value={item.value}
               key={item.value}
-              aria-label={item.label}
+              aria-label={`Exclude Documents ${item.label}`} // use a different aria-label to avoid duplicate labels for accessibility
             >
               {item.label}
             </StyledToggleButton>

--- a/src/components/filter/tab-filters/DataSettingsFilter.tsx
+++ b/src/components/filter/tab-filters/DataSettingsFilter.tsx
@@ -2,6 +2,7 @@ import React, { FC, useCallback } from "react";
 import { Box, Stack, SxProps, Typography } from "@mui/material";
 import {
   updateHasData,
+  updateExcludeDocument,
   updateStatus,
   updateUpdateFreq,
 } from "../../common/store/componentParamReducer";
@@ -20,6 +21,7 @@ enum DataSettingsCategory {
   dataDeliverMode = "dataDeliveryMode",
   dataDeliveryFrequency = "dataDeliveryFrequency",
   dataIndexedType = "dataIndexedType",
+  excludeDocument = "excludeDocument",
   dataService = "dataService",
   dataStatus = "dataStatus",
 }
@@ -44,6 +46,12 @@ const DATA_SETTINGS: DataSettingsFilterType = {
   dataIndexedType: [
     {
       value: IndexDataType.CLOUD,
+      label: "Yes",
+    },
+  ],
+  excludeDocument: [
+    {
+      value: "Yes",
       label: "Yes",
     },
   ],
@@ -143,6 +151,14 @@ const DataSettingsFilter: FC<DataSettingsFilterProps> = ({
             dataIndexedType: newAlignment as Array<IndexDataType>,
           }));
           dispatch(updateHasData(values?.includes(IndexDataType.CLOUD)));
+        }
+        if (category === DataSettingsCategory.excludeDocument) {
+          const values = newAlignment as Array<string>;
+          setFilters((prevFilters) => ({
+            ...prevFilters,
+            excludeDocument: values,
+          }));
+          dispatch(updateExcludeDocument(values?.includes("Yes")));
         }
         if (category === DataSettingsCategory.dataStatus) {
           const value = newAlignment as DatasetStatus | null;
@@ -263,6 +279,50 @@ const DataSettingsFilter: FC<DataSettingsFilterProps> = ({
           }}
         >
           {DATA_SETTINGS.dataIndexedType.map((item) => (
+            <StyledToggleButton
+              value={item.value}
+              key={item.value}
+              aria-label={item.label}
+            >
+              {item.label}
+            </StyledToggleButton>
+          ))}
+        </StyledToggleButtonGroup>
+      </Box>
+      <Box>
+        <Typography
+          sx={{
+            ...portalTheme.typography.title1Medium,
+            color: portalTheme.palette.text1,
+            fontWeight: 500,
+            padding: "8px 20px",
+          }}
+        >
+          Exclude Document
+        </Typography>
+        <StyledToggleButtonGroup
+          value={filters.excludeDocument}
+          onChange={handleChange(DataSettingsCategory.excludeDocument)}
+          sx={{
+            gap: "14px 12px",
+            "& .MuiToggleButton-root": {
+              borderRadius: "6px",
+              textTransform: "capitalize",
+              ...portalTheme.typography.title2Regular,
+              color: portalTheme.palette.text1,
+              bgcolor: "#fff",
+              border: `1px solid ${portalTheme.palette.grey500}`,
+              px: "38px",
+              py: "8px",
+              "&.Mui-selected": {
+                border: "none",
+                bgcolor: portalTheme.palette.primary1,
+                color: "#fff",
+              },
+            },
+          }}
+        >
+          {DATA_SETTINGS.excludeDocument.map((item) => (
             <StyledToggleButton
               value={item.value}
               key={item.value}

--- a/src/components/layout/components/Header.tsx
+++ b/src/components/layout/components/Header.tsx
@@ -61,7 +61,8 @@ const Header: FC = () => {
     !!(params.platform && params.platform.length > 0) ||
     !!params.updateFreq ||
     !!params.datasetStatus ||
-    !!params.hasCOData;
+    !!params.hasCOData ||
+    !!params.excludeDocument;
 
   return (
     <Box

--- a/src/components/search/ActiveFiltersChips.tsx
+++ b/src/components/search/ActiveFiltersChips.tsx
@@ -8,6 +8,7 @@ import {
   SelectedStaticArea,
   updateDatasetGroup,
   updateDateTimeFilterRange,
+  updateExcludeDocument,
   updateFilterPolygon,
   updateFilterStaticAreas,
   updateHasData,
@@ -202,6 +203,17 @@ const ActiveFiltersChips: FC = () => {
         label: `Status: ${DATA_SETTINGS.dataStatus.find((f) => f.value === params.datasetStatus)?.label || params.datasetStatus}`,
         onDelete: () => {
           dispatch(updateStatus(undefined));
+          triggerRedirectIfOnSearchPage();
+        },
+      });
+    }
+
+    // Exclude document datasets
+    if (params.excludeDocument) {
+      chips.push({
+        label: "Exclude Document",
+        onDelete: () => {
+          dispatch(updateExcludeDocument(false));
           triggerRedirectIfOnSearchPage();
         },
       });

--- a/src/components/search/SearchbarButtonGroup.tsx
+++ b/src/components/search/SearchbarButtonGroup.tsx
@@ -67,6 +67,10 @@ const checkCount = ({
         count++;
       }
 
+      if (filterObj.excludeDocument) {
+        count++;
+      }
+
       if (filterObj.hasCOData) {
         count++;
       }

--- a/src/pages/landing-page/subpages/topics-panel/TopicsPanel.tsx
+++ b/src/pages/landing-page/subpages/topics-panel/TopicsPanel.tsx
@@ -14,6 +14,8 @@ import TopicCard, { TopicCardType } from "./TopicCard";
 import {
   clearComponentParam,
   updateDatasetGroup,
+  updateExcludeDocument,
+  updateHasData,
   updateSearchText,
 } from "../../../../components/common/store/componentParamReducer";
 import { portalTheme } from "../../../../styles";
@@ -197,7 +199,20 @@ const TopicsPanel: FC<TopicsPanelProps> = () => {
       {
         title: "Gridded Datasets",
         icon: IconGriddedDatasets,
-        handler: () => handleClickTopicCard("Gridded Datasets"),
+        handler: () => {
+          // Clear the component states
+          dispatch(clearComponentParam());
+          // Then update the search text with the selected topic value
+          dispatch(updateSearchText("Gridded Datasets"));
+          dispatch(updateExcludeDocument(true));
+          dispatch(updateHasData(true));
+          // Track topics panel button click
+          trackCustomEvent(AnalyticsEvent.SEARCH_TOPIC_CLICK, {
+            search_topic: "Gridded Datasets",
+          });
+
+          redirectSearch("TopicsPanel");
+        },
       },
       {
         title: "Ocean Physics",
@@ -227,7 +242,20 @@ const TopicsPanel: FC<TopicsPanelProps> = () => {
       {
         title: "Time Series Datasets",
         icon: IconTimeSeriesDatasets,
-        handler: () => handleClickTopicCard("Time Series Datasets"),
+        handler: () => {
+          // Clear the component states
+          dispatch(clearComponentParam());
+          // Then update the search text with the selected topic value
+          dispatch(updateSearchText("Time Series Datasets"));
+          dispatch(updateExcludeDocument(true));
+          dispatch(updateHasData(true));
+          // Track topics panel button click
+          trackCustomEvent(AnalyticsEvent.SEARCH_TOPIC_CLICK, {
+            search_topic: "Time Series Datasets",
+          });
+
+          redirectSearch("TopicsPanel");
+        },
       },
     ],
     [dispatch, handleClickTopicCard, redirectSearch]

--- a/src/utils/UrlUtils.tsx
+++ b/src/utils/UrlUtils.tsx
@@ -8,6 +8,7 @@ const paramLookup: Map<string, string> = new Map<string, string>([
   ["bbox.type", "B4"],
   ["datasetGroup", "I1"],
   ["hasCOData", "I2"],
+  ["excludeDocument", "I3"],
   ["polygon.geometry.coordinates", "P1"],
   ["polygon.geometry.type", "P2"],
   ["polygon.type", "P3"],


### PR DESCRIPTION
Adds a new Exclude Documents toggle to the Data Settings filter tab. When enabled, the search request appends the CQL clause NOT (scope='document'), removing document-scope records from results.
<img width="1608" height="620" alt="image" src="https://github.com/user-attachments/assets/8836dc93-8d7e-497b-9291-3c23172e50cf" />

The Gridded Datasets and Time Series Datasets topic cards on the landing page now apply excludeDocument = true and hasCOData = true automatically, so those shortcuts return only downloadable, non-document datasets.
<img width="3400" height="462" alt="image" src="https://github.com/user-attachments/assets/d80a159f-c49f-4277-921e-c7c31fe16740" />
