### PR TITLE
fix: center detail maps for antimeridian and near-global bbox

### DIFF
--- a/src/utils/MapUtils.tsx
+++ b/src/utils/MapUtils.tsx
@@ -1,5 +1,6 @@
 import { Root } from "react-dom/client";
 import {
+  LngLat,
   LngLatBoundsLike,
   Map as MapboxMap,
   MercatorCoordinate,
@@ -75,14 +76,21 @@ const half = worldSize / 2;
 const ensureEastGreaterThanWest = (west: number, east: number): number =>
   east < west ? east + 360 : east;
 
-const AUSTRALIA_CENTER: [number, number] = [
+const AUSTRALIA_CENTER_LNG =
   (MapDefaultConfig.BBOX_ENDPOINTS.WEST_LON +
     MapDefaultConfig.BBOX_ENDPOINTS.EAST_LON) /
-    2,
-  (MapDefaultConfig.BBOX_ENDPOINTS.SOUTH_LAT +
-    MapDefaultConfig.BBOX_ENDPOINTS.NORTH_LAT) /
-    2,
-];
+  2;
+
+// Only recentre when the bbox actually reaches Australia's longitudes,
+// otherwise data such as an Atlantic-hemisphere bbox would end up off-screen
+const overlapsAustraliaLng = (west: number, east: number): boolean => {
+  const { WEST_LON, EAST_LON } = MapDefaultConfig.BBOX_ENDPOINTS;
+  return (
+    Math.max(west, WEST_LON) <= Math.min(east, EAST_LON) ||
+    // for bboxes unwrapped past 180, Australia repeats at +360
+    Math.max(west, WEST_LON + 360) <= Math.min(east, EAST_LON + 360)
+  );
+};
 
 // A bbox this wide (or tall — catches degenerate metadata like
 // [180, -71, 180, 63]) fits at world-level zoom anyway, so the view is
@@ -147,9 +155,14 @@ export const fitToBound = (
 
       // Use flyTo for more control over the viewport
       map.flyTo({
-        center: isWorldScale(west, south, east, north)
-          ? AUSTRALIA_CENTER
-          : camera.center,
+        // Swap only the lng and keep the computed lat, so high-latitude
+        // data (e.g. around Antarctica) stays in view
+        center:
+          camera.center !== undefined &&
+          isWorldScale(west, south, east, north) &&
+          overlapsAustraliaLng(west, east)
+            ? [AUSTRALIA_CENTER_LNG, LngLat.convert(camera.center).lat]
+            : camera.center,
         zoom: camera.zoom,
         animate: animate,
       });

--- a/src/utils/MapUtils.tsx
+++ b/src/utils/MapUtils.tsx
@@ -111,6 +111,11 @@ const isWorldScale = (
  * based on the map container's dimensions.
  * TODO: This temporary resolve fitting map to bound cut off problem, can refactor if have better solution
  *
+ * Zoom and lat always follow the record's own bbox. The only intervention
+ * (bug 8271): when the bbox is world-scale AND reaches Australia's longitudes,
+ * the view centre's lng is swapped to Australia so the world view is centred
+ * on Australia instead of the Atlantic. Everything else fits as-is.
+ *
  * @param map - The Mapbox map instance
  * @param bbox - Array of positions representing the bounding box
  * @param options - Additional options for fitting the bbox

--- a/src/utils/MapUtils.tsx
+++ b/src/utils/MapUtils.tsx
@@ -70,6 +70,34 @@ const BBOX_COORDINATES_COUNT = 4;
 const worldSize = 40075016.68; // Full projected width/height in meters
 const half = worldSize / 2;
 
+// Keep east greater than west for bbox crossing the antimeridian,
+// otherwise cameraForBounds fits the opposite side of the globe
+const ensureEastGreaterThanWest = (west: number, east: number): number =>
+  east < west ? east + 360 : east;
+
+const AUSTRALIA_CENTER: [number, number] = [
+  (MapDefaultConfig.BBOX_ENDPOINTS.WEST_LON +
+    MapDefaultConfig.BBOX_ENDPOINTS.EAST_LON) /
+    2,
+  (MapDefaultConfig.BBOX_ENDPOINTS.SOUTH_LAT +
+    MapDefaultConfig.BBOX_ENDPOINTS.NORTH_LAT) /
+    2,
+];
+
+// A bbox this wide (or tall — catches degenerate metadata like
+// [180, -71, 180, 63]) fits at world-level zoom anyway, so the view is
+// centred on Australia instead of the bbox's own centre
+const WORLD_SCALE_LNG_SPAN = 180;
+const WORLD_SCALE_LAT_SPAN = 90;
+
+const isWorldScale = (
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): boolean =>
+  east - west >= WORLD_SCALE_LNG_SPAN || north - south >= WORLD_SCALE_LAT_SPAN;
+
 /**
  * Fits the map view to the specified bounding box with intelligent zoom calculation
  * based on the map container's dimensions.
@@ -101,23 +129,28 @@ export const fitToBound = (
 
     const boundsArray = bbox as number[];
     if (boundsArray && boundsArray.length === BBOX_COORDINATES_COUNT) {
-      const [west, south, east, north] = boundsArray;
+      const [west, south, rawEast, north] = boundsArray;
+      const east = ensureEastGreaterThanWest(west, rawEast);
       const bounds: LngLatBoundsLike = [
         [west, south],
-        // cameraForBounds do not handle cross antimeridian
-        // and takes shortest path (Atlantic-centered).
-        [east > 180 ? east - 360 : east, north],
+        [east, north],
       ];
 
-      const { center, zoom } = map.cameraForBounds(bounds, {
+      const camera = map.cameraForBounds(bounds, {
         padding: 20, // or zoomOffset equivalent
         maxZoom: baseZoom,
-      })!;
+      });
+      if (!camera) {
+        console.error("cameraForBounds returned no camera for:", bounds);
+        return;
+      }
 
       // Use flyTo for more control over the viewport
       map.flyTo({
-        center: center,
-        zoom: zoom,
+        center: isWorldScale(west, south, east, north)
+          ? AUSTRALIA_CENTER
+          : camera.center,
+        zoom: camera.zoom,
         animate: animate,
       });
     } else {

--- a/src/utils/__test__/MapUtils.test.ts
+++ b/src/utils/__test__/MapUtils.test.ts
@@ -150,8 +150,9 @@ describe("MapUtils", () => {
     );
   });
 
-  // centre of BBOX_ENDPOINTS, written out by hand on purpose
-  const AUSTRALIA_CENTER = [133.5, -25.5];
+  // lng of BBOX_ENDPOINTS centre written out by hand on purpose;
+  // lat is kept from cameraForBounds, which the mock returns as 0
+  const RECENTRED = [133.5, 0];
 
   it("centred on Australia (but zoomed out to show most of world) for near-global bbox", () => {
     const map = createMockMap();
@@ -166,7 +167,7 @@ describe("MapUtils", () => {
       expect.objectContaining({ padding: 20 })
     );
     expect(map.flyTo).toHaveBeenCalledWith(
-      expect.objectContaining({ center: AUSTRALIA_CENTER, zoom: 5 })
+      expect.objectContaining({ center: RECENTRED, zoom: 5 })
     );
   });
 
@@ -183,17 +184,41 @@ describe("MapUtils", () => {
       expect.objectContaining({ padding: 20 })
     );
     expect(map.flyTo).toHaveBeenCalledWith(
-      expect.objectContaining({ center: AUSTRALIA_CENTER })
+      expect.objectContaining({ center: RECENTRED })
     );
   });
 
-  it("centred on Australia (but zoomed out to show most of world) for degenerate bbox with hemisphere lat span", () => {
+  it("keeps own centre for degenerate bbox whose lng misses Australia (already looks practically right)", () => {
     const map = createMockMap();
 
     fitToBound(map, [180, -71, 180, 63]); // ec2c0ef9-3645-4ded-b617-c8297f6eb250
 
     expect(map.flyTo).toHaveBeenCalledWith(
-      expect.objectContaining({ center: AUSTRALIA_CENTER })
+      expect.objectContaining({ center: [0, 0] })
+    );
+  });
+
+  it("keeps own centre for world-scale bbox that never reaches Australia", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [-180, -60, 0, 60]); // atlantic hemisphere
+
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [0, 0] })
+    );
+  });
+
+  it("keeps computed lat when recentring, so high-latitude data stays in view", () => {
+    const map = createMockMap();
+    (map.cameraForBounds as ReturnType<typeof vi.fn>).mockReturnValue({
+      center: [0, -67],
+      zoom: 1,
+    });
+
+    fitToBound(map, [-180, -80, 180, -55]); // circumpolar southern ocean
+
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [133.5, -67], zoom: 1 })
     );
   });
 

--- a/src/utils/__test__/MapUtils.test.ts
+++ b/src/utils/__test__/MapUtils.test.ts
@@ -115,36 +115,140 @@ describe("MapUtils", () => {
     ]);
   });
 
-  it("adjusts east > 180 by subtracting 360 for Pacific bbox", () => {
-    const map = {
+  const createMockMap = () =>
+    ({
       resize: vi.fn(),
       cameraForBounds: vi.fn().mockReturnValue({ center: [0, 0], zoom: 5 }),
       flyTo: vi.fn(),
-    } as unknown as MapboxMap;
+    }) as unknown as MapboxMap;
 
-    const bbox = [176, -72, 276, -48]; // crosses antimeridian
+  it("keeps east unchanged when it is greater than west", () => {
+    const map = createMockMap();
 
-    fitToBound(map, bbox);
+    fitToBound(map, [176, -72, 276, -48]); // crosses antimeridian
 
     expect(map.cameraForBounds).toHaveBeenCalledWith(
       [
         [176, -72],
-        [276 - 360, -48],
+        [276, -48],
       ],
       expect.objectContaining({ padding: 20 })
     );
   });
 
+  it("adds 360 to east when it is smaller than west", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [170, -40, -160, -10]); // crosses antimeridian
+
+    expect(map.cameraForBounds).toHaveBeenCalledWith(
+      [
+        [170, -40],
+        [200, -10],
+      ],
+      expect.objectContaining({ padding: 20 })
+    );
+  });
+
+  // centre of BBOX_ENDPOINTS, written out by hand on purpose
+  const AUSTRALIA_CENTER = [133.5, -25.5];
+
+  it("centred on Australia (but zoomed out to show most of world) for near-global bbox", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [2, -68, 359, 79]); // 997c2e15-b345-438f-afac-49a4ac19be38
+
+    expect(map.cameraForBounds).toHaveBeenCalledWith(
+      [
+        [2, -68],
+        [359, 79],
+      ],
+      expect.objectContaining({ padding: 20 })
+    );
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: AUSTRALIA_CENTER, zoom: 5 })
+    );
+  });
+
+  it("centred on Australia (but zoomed out to show most of world) when lng span exceeds half the globe", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [120, -78, 350, 38]); // 95d6314c-cfc7-40ae-b439-85f14541db71
+
+    expect(map.cameraForBounds).toHaveBeenCalledWith(
+      [
+        [120, -78],
+        [350, 38],
+      ],
+      expect.objectContaining({ padding: 20 })
+    );
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: AUSTRALIA_CENTER })
+    );
+  });
+
+  it("centred on Australia (but zoomed out to show most of world) for degenerate bbox with hemisphere lat span", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [180, -71, 180, 63]); // ec2c0ef9-3645-4ded-b617-c8297f6eb250
+
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: AUSTRALIA_CENTER })
+    );
+  });
+
+  it("zoomed in to dataset, which is Australia (wide bbox keeps its own centre)", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [80, -60, 179.9, 10]); // b35b829c-9149-46c6-9e25-d0fd03463280
+
+    expect(map.cameraForBounds).toHaveBeenCalledWith(
+      [
+        [80, -60],
+        [179.9, 10],
+      ],
+      expect.objectContaining({ padding: 20 })
+    );
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [0, 0], zoom: 5 })
+    );
+  });
+
+  it("zoomed in to dataset (tasmania)", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [145, -44, 147.5, -40]); // 78d588ed-79dd-47e2-b806-d39025194e7e
+
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [0, 0] })
+    );
+  });
+
+  it("zoomed in to dataset (single point)", () => {
+    const map = createMockMap();
+
+    fitToBound(map, [-144.6333, -10.8833, -144.6333, -10.8833]); // 736fe6f0-8db6-11dc-92db-00008a07204e
+
+    expect(map.flyTo).toHaveBeenCalledWith(
+      expect.objectContaining({ center: [0, 0] })
+    );
+  });
+
+  it("does not fly anywhere when cameraForBounds returns no camera", () => {
+    const map = createMockMap();
+    (map.cameraForBounds as ReturnType<typeof vi.fn>).mockReturnValue(
+      undefined
+    );
+
+    fitToBound(map, [145, -44, 147.5, -40]);
+
+    expect(map.flyTo).not.toHaveBeenCalled();
+  });
+
   it("does not adjust when east <= 180", () => {
-    const map = {
-      resize: vi.fn(),
-      cameraForBounds: vi.fn().mockReturnValue({ center: [0, 0], zoom: 5 }),
-      flyTo: vi.fn(),
-    } as unknown as MapboxMap;
+    const map = createMockMap();
 
-    const bbox = [-10, -20, 30, 40];
-
-    fitToBound(map, bbox);
+    fitToBound(map, [-10, -20, 30, 40]);
 
     expect(map.cameraForBounds).toHaveBeenCalledWith(
       [


### PR DESCRIPTION
<img width="1576" height="791" alt="Screenshot 2026-07-17 at 12 07 38" src="https://github.com/user-attachments/assets/1b867d8f-c1e9-4728-8d15-a5f24c0d3e09" />
<img width="1568" height="785" alt="Screenshot 2026-07-17 at 12 08 09" src="https://github.com/user-attachments/assets/e8d9e1f8-552b-4ae1-a827-c40e66e3fe6e" />
<img width="1580" height="752" alt="Screenshot 2026-07-17 at 12 08 41" src="https://github.com/user-attachments/assets/c4590153-b8e0-44cb-8bc6-d49749594656" />
<img width="1570" height="984" alt="Screenshot 2026-07-17 at 12 09 18" src="https://github.com/user-attachments/assets/70c72487-ac6b-4c39-a90b-db64a03193d3" />
<img width="1569" height="821" alt="Screenshot 2026-07-17 at 12 09 43" src="https://github.com/user-attachments/assets/327e7ba1-3303-4f66-906e-4ff2115998f9
<img width="1569" height="762" alt="Screenshot 2026-07-17 at 12 10 10" src="https://github.com/user-attachments/assets/252e5909-9711-4a68-b1c4-6842c6356b03" />
<img width="1569" height="821" alt="Screenshot 2026-07-17 at 12 09 43" src="https://github.com/user-attachments/assets/eac8a84d-6c5e-4df6-872c-80de1dc69869" />
<img width="1569" height="762" alt="Screenshot 2026-07-17 at 12 10 10" src="https://github.com/user-attachments/assets/9e5baf37-ecbb-47e0-997e-038b8c7932c3" />
<img width="1563" height="749" alt="Screenshot 2026-07-17 at 12 10 48" src="https://github.com/user-attachments/assets/d2450af9-7616-448a-a055-0c896cc1cad6" />
<img width="1563" height="774" alt="Screenshot 2026-07-17 at 12 11 12" src="https://github.com/user-attachments/assets/e6528acd-d826-4661-808c-ec98d169856a" />
