### PR TITLE
Feature/8070 add double quote suggestion

### DIFF
--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -38,7 +38,11 @@ import { pageDefault } from "../common/constants";
 import useBreakpoint from "../../hooks/useBreakpoint";
 import { portalTheme } from "../../styles";
 import LabelChip from "../common/label/LabelChip";
-import { isQuotedPhrase, quotePhrase } from "../../utils/StringUtils";
+import {
+  isQuotedPhrase,
+  quotePhrase,
+  stripQuotes,
+} from "../../utils/StringUtils";
 
 interface InputWithSuggesterProps {
   containerRef?: HTMLDivElement | null;
@@ -153,9 +157,9 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
             );
 
             // add an exact-keyword-only option of what the user typed at the first position
-            const typed = inputValue.trim();
-            if (options.length > 0 && typed && !isQuotedPhrase(typed)) {
-              options.splice(1, 0, {
+            const typed = stripQuotes(inputValue);
+            if (typed && !isQuotedPhrase(inputValue.trim())) {
+              options.splice(0, 0, {
                 text: quotePhrase(typed),
                 group: OptionGroup.QUOTED,
               });

--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -13,6 +13,7 @@ import {
   Autocomplete,
   AutocompleteInputChangeReason,
   Box,
+  createFilterOptions,
   Paper,
   Popper,
   TextField,
@@ -72,6 +73,8 @@ enum OptionGroup {
   PLATFORM = "platform",
   QUOTED = "quoted",
 }
+
+const defaultFilter = createFilterOptions<string>();
 
 /**
  * Customized input box with suggester. If more customization is needed, please
@@ -156,11 +159,10 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
               }
             );
 
-            // add an exact-keyword-only option of what the user typed at the first position
-            const typed = stripQuotes(inputValue);
-            if (typed && !isQuotedPhrase(inputValue.trim())) {
-              options.splice(0, 0, {
-                text: quotePhrase(typed),
+            // add an exact-keyword-only option of what the user typed at the second position
+            if (stripQuotes(inputValue) && !isQuotedPhrase(inputValue.trim())) {
+              options.splice(1, 0, {
+                text: quotePhrase(inputValue),
                 group: OptionGroup.QUOTED,
               });
             }
@@ -355,6 +357,17 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
       value={inputValue}
       forcePopupIcon={false}
       options={options.flatMap((option) => option.text)}
+      // The exact-keyword option is built from cleaned up text (quotes removed, extra spaces collapsed),
+      // typing "sea " builds the option "sea", which has no trailing space to match. So run MUI's own
+      // filter first, then add the exact-keyword option back if it was dropped.
+      filterOptions={(opts, state) => {
+        const kept = defaultFilter(opts, state);
+        const quoted = quotePhrase(state.inputValue);
+        if (opts.includes(quoted) && !kept.includes(quoted)) {
+          kept.splice(1, 0, quoted);
+        }
+        return kept;
+      }}
       autoComplete
       includeInputInList
       disablePortal

--- a/src/components/search/InputWithSuggester.tsx
+++ b/src/components/search/InputWithSuggester.tsx
@@ -27,16 +27,18 @@ import {
   createSuggesterParamFrom,
   fetchSuggesterOptions,
 } from "@/app/store/searchReducer";
-import { borderRadius, color, padding } from "../../styles/constants";
+import { borderRadius, color, gap, padding } from "../../styles/constants";
 import { debounce } from "lodash";
 import { sortByRelevance } from "../../utils/Helpers";
 import { useAppDispatch } from "@/app/store/hooks";
-import { TEXT_FIELD_MIN_WIDTH } from "./constants";
+import { DOUBLE_QUOTE_LABEL, TEXT_FIELD_MIN_WIDTH } from "./constants";
 import { SearchbarButtonNames } from "./SearchbarButtonGroup";
 import { useLocation } from "react-router-dom";
 import { pageDefault } from "../common/constants";
 import useBreakpoint from "../../hooks/useBreakpoint";
 import { portalTheme } from "../../styles";
+import LabelChip from "../common/label/LabelChip";
+import { isQuotedPhrase, quotePhrase } from "../../utils/StringUtils";
 
 interface InputWithSuggesterProps {
   containerRef?: HTMLDivElement | null;
@@ -64,6 +66,7 @@ enum OptionGroup {
   PHRASE = "phrase",
   ORGANIZATION = "organization",
   PLATFORM = "platform",
+  QUOTED = "quoted",
 }
 
 /**
@@ -148,6 +151,15 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
                 }
               }
             );
+
+            // add an exact-keyword-only option of what the user typed at the first position
+            const typed = inputValue.trim();
+            if (options.length > 0 && typed && !isQuotedPhrase(typed)) {
+              options.splice(1, 0, {
+                text: quotePhrase(typed),
+                group: OptionGroup.QUOTED,
+              });
+            }
 
             setOptions(options);
           });
@@ -390,6 +402,16 @@ const InputWithSuggester: FC<InputWithSuggesterProps> = ({
       renderOption={(props, option) => (
         <li {...props}>
           {option}
+          {isQuotedPhrase(option) && (
+            <LabelChip
+              text={[DOUBLE_QUOTE_LABEL]}
+              color={portalTheme.palette.tag1}
+              sx={{
+                ml: gap.lg,
+                ...portalTheme.typography.body2Regular,
+              }}
+            />
+          )}
           {/* hidden by default, shown on focus, check sx in CustomPaper */}
           <SearchIcon sx={{ display: "none", ml: "auto" }} />
         </li>

--- a/src/components/search/__test__/InputWithSuggester.test.tsx
+++ b/src/components/search/__test__/InputWithSuggester.test.tsx
@@ -191,4 +191,29 @@ describe("InputWithSuggester", () => {
     // 4. Verify suggestions are cleared (as per your handleSearchbarClose logic)
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
+
+  it("offers a double-quoted 'Only keyword' option for the typed text", async () => {
+    const user = userEvent.setup();
+    const input = screen.getByTestId("input-with-suggester");
+
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, "wave");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).toBeInTheDocument();
+    });
+
+    // The quoted row and its chip are rendered
+    const quotedOption = await screen.findByText('"wave"');
+    expect(screen.getByTestId("label-chip-Only keyword")).toBeInTheDocument();
+
+    // Selecting it puts the quoted text into the input and Redux
+    await user.click(quotedOption);
+
+    await waitFor(() => {
+      expect(input).toHaveValue('"wave"');
+      expect(store.getState().paramReducer.searchText).toBe('"wave"');
+    });
+  });
 });

--- a/src/components/search/constants.ts
+++ b/src/components/search/constants.ts
@@ -19,3 +19,5 @@ export enum SearchKeys {
   CSIRO = "csiro",
   IMAS = "imas",
 }
+
+export const DOUBLE_QUOTE_LABEL = "Only keyword";

--- a/src/utils/StringUtils.tsx
+++ b/src/utils/StringUtils.tsx
@@ -101,8 +101,12 @@ export const getLinkType = (text: string): "email" | "url" | "text" => {
   return "text";
 };
 
-// Helper to wrap text in double quotes for an exact-keyword-only search, e.g. mooring -> "mooring"
-export const quotePhrase = (text: string): string => `"${text}"`;
+// Helper to remove double quotes and collapse whitespace, e.g. sea  "surface" -> sea surface
+export const stripQuotes = (text: string): string =>
+  text.replace(/"/g, "").replace(/\s+/g, " ").trim();
 
-export const isQuotedPhrase = (text: string): boolean =>
-  text.length > 1 && text.startsWith('"') && text.endsWith('"');
+// Helper to wrap text in double quotes for an exact-keyword-only search, e.g. mooring -> "mooring"
+// e.g. "wave -> "wave" and sea "surface" -> "sea surface"
+export const quotePhrase = (text: string): string => `"${stripQuotes(text)}"`;
+
+export const isQuotedPhrase = (text: string): boolean => /^"[^"]+"$/.test(text);

--- a/src/utils/StringUtils.tsx
+++ b/src/utils/StringUtils.tsx
@@ -100,3 +100,9 @@ export const getLinkType = (text: string): "email" | "url" | "text" => {
   if (isUrl(text)) return "url";
   return "text";
 };
+
+// Helper to wrap text in double quotes for an exact-keyword-only search, e.g. mooring -> "mooring"
+export const quotePhrase = (text: string): string => `"${text}"`;
+
+export const isQuotedPhrase = (text: string): boolean =>
+  text.length > 1 && text.startsWith('"') && text.endsWith('"');

--- a/src/utils/__test__/StringUtils.test.ts
+++ b/src/utils/__test__/StringUtils.test.ts
@@ -3,6 +3,9 @@ import {
   createFilterString,
   decodeHtmlEntities,
   formatNumber,
+  isQuotedPhrase,
+  quotePhrase,
+  stripQuotes,
   truncateText,
 } from "../StringUtils";
 
@@ -122,5 +125,50 @@ describe("createFilterString", () => {
     expect(createFilterString(["uuid1", "uuid2"])).toBe(
       "id IN ('uuid1','uuid2')"
     );
+  });
+});
+
+describe("stripQuotes", () => {
+  it("should leave plain text untouched", () => {
+    expect(stripQuotes("wave")).toBe("wave");
+  });
+
+  it("should remove a leading or trailing quote", () => {
+    expect(stripQuotes('"wave')).toBe("wave");
+    expect(stripQuotes('wave"')).toBe("wave");
+  });
+
+  it("should remove quotes from inside the text", () => {
+    expect(stripQuotes('sea "surface"')).toBe("sea surface");
+    expect(stripQuotes('"wave" or "swell"')).toBe("wave or swell");
+  });
+
+  it("should collapse and trim whitespace", () => {
+    expect(stripQuotes("sea  surface ")).toBe("sea surface");
+  });
+
+  it("should return an empty string when only quotes and spaces are given", () => {
+    expect(stripQuotes('"')).toBe("");
+    expect(stripQuotes('""')).toBe("");
+    expect(stripQuotes('"""')).toBe("");
+    expect(stripQuotes('"  "')).toBe("");
+  });
+});
+
+describe("quotePhrase", () => {
+  it("should wrap plain text in double quotes", () => {
+    expect(quotePhrase("mooring")).toBe('"mooring"');
+  });
+
+  it("should produce balanced quotes from half-quoted text", () => {
+    expect(quotePhrase('"wave')).toBe('"wave"');
+  });
+
+  it("should not nest quotes when the text is already quoted", () => {
+    expect(quotePhrase('"wave"')).toBe('"wave"');
+  });
+
+  it("should return an empty phrase when nothing is left after stripping", () => {
+    expect(quotePhrase('"')).toBe('""');
   });
 });

--- a/src/utils/__test__/StringUtils.test.ts
+++ b/src/utils/__test__/StringUtils.test.ts
@@ -3,7 +3,6 @@ import {
   createFilterString,
   decodeHtmlEntities,
   formatNumber,
-  isQuotedPhrase,
   quotePhrase,
   stripQuotes,
   truncateText,


### PR DESCRIPTION
Added autocomplete support for the double-quote search suggestion.

This follows the design discussed here: https://github.com/aodn/backlog/issues/8070#issuecomment-5055012548 Note: the chip colour is not fully aligned with the design yet. I'll update it once I have Figma dev mode permission.

FE demo:
<img width="1157" height="413" alt="image" src="https://github.com/user-attachments/assets/dad5c311-7311-43a0-8962-9f129649d2ad" />

<img width="2346" height="383" alt="image" src="https://github.com/user-attachments/assets/a4d118d8-0fdc-4f59-8521-db5964adb55f" />

