### PR TITLE
Bugfix/8736 fix dataset status mapping

### DIFF
--- a/src/components/result/ResultCardButtonGroup.tsx
+++ b/src/components/result/ResultCardButtonGroup.tsx
@@ -29,10 +29,12 @@ interface ButtonContainerProps {
   sx?: SxProps;
 }
 
-enum Status {
-  Ongoing = "ongoing",
-  Completed = "completed",
-}
+// Lowercased status values accepted for each button, as the records use several
+// spellings for the same status and may combine codes into one string
+const Status = {
+  Ongoing: ["ongoing", "ongoing | historicalarchive"],
+  Completed: ["completed", "complete"],
+};
 
 const renderStatusButton = (
   shouldHideText: boolean,
@@ -40,7 +42,7 @@ const renderStatusButton = (
   resultCardButtonConfig?: ResultCardButtonConfig
 ) => {
   const status = content?.getStatus()?.toLowerCase().trim();
-  if (status === Status.Completed || status === "complete") {
+  if (status && Status.Completed.includes(status)) {
     return (
       <ResultCardButton
         startIcon={TaskAltSharpIcon}
@@ -50,7 +52,7 @@ const renderStatusButton = (
       />
     );
   }
-  if (status?.startsWith(Status.Ongoing)) {
+  if (status && Status.Ongoing.includes(status)) {
     return (
       <ResultCardButton
         startIcon={DoubleArrowIcon}

--- a/src/components/result/ResultCardButtonGroup.tsx
+++ b/src/components/result/ResultCardButtonGroup.tsx
@@ -40,7 +40,7 @@ const renderStatusButton = (
   resultCardButtonConfig?: ResultCardButtonConfig
 ) => {
   const status = content?.getStatus()?.toLowerCase().trim();
-  if (status === Status.Completed) {
+  if (status?.startsWith(Status.Completed)) {
     return (
       <ResultCardButton
         startIcon={TaskAltSharpIcon}
@@ -50,7 +50,7 @@ const renderStatusButton = (
       />
     );
   }
-  if (status === Status.Ongoing) {
+  if (status?.startsWith(Status.Ongoing)) {
     return (
       <ResultCardButton
         startIcon={DoubleArrowIcon}

--- a/src/components/result/ResultCardButtonGroup.tsx
+++ b/src/components/result/ResultCardButtonGroup.tsx
@@ -40,7 +40,7 @@ const renderStatusButton = (
   resultCardButtonConfig?: ResultCardButtonConfig
 ) => {
   const status = content?.getStatus()?.toLowerCase().trim();
-  if (status?.startsWith(Status.Completed)) {
+  if (status === Status.Completed || status === "complete") {
     return (
       <ResultCardButton
         startIcon={TaskAltSharpIcon}


### PR DESCRIPTION
FE demo:
1. status = "complete" (example uuid: `45d0c70c-ee4d-4727-8d86-daacb2d29156`)

<img width="1641" height="388" alt="Image" src="https://github.com/user-attachments/assets/934b3baa-16ef-4e8c-a29c-21a496c319fb" />

2. status = "onGoing | historicalArchive" (example uuid: `ddfe08f0-e4bc-11dc-9b6b-00188b4c0af8`):

<img width="1599" height="383" alt="Image" src="https://github.com/user-attachments/assets/a6f0ec3a-8581-4a5b-beba-30454dde0fb5" />
