### PR TITLE
Bugfix/8751 time slider boundary

### DIFF
--- a/playwright/tests/search_page/test_search_page.py
+++ b/playwright/tests/search_page/test_search_page.py
@@ -264,6 +264,8 @@ def test_data_bookmark_persistence(desktop_page: Page, data_id: str) -> None:
 
     landing_page.load()
     landing_page.search.search_for(data_id)
+    search_page.wait_for_search_to_complete()
+    search_page.map.wait_for_map_idle()
 
     # Click result card bookmark icon
     search_page.get_bookmark_icon(data_id, search_page.result_card_list).click()
@@ -271,9 +273,15 @@ def test_data_bookmark_persistence(desktop_page: Page, data_id: str) -> None:
 
     # Clear search to show all results
     search_page.search.search_for('')
+    search_page.wait_for_search_to_complete()
     search_page.map.wait_for_map_idle()
     # Search again to see if bookmark persists
     search_page.search.search_for(data_id)
+    search_page.wait_for_search_to_complete()
     search_page.map.wait_for_map_idle()
+    # Ensure the dataset result card is back before checking bookmark state
+    search_page.get_bookmark_icon(
+        data_id, search_page.result_card_list
+    ).wait_for(state='visible')
 
     search_page.assert_bookmark_state(data_id, True)

--- a/src/components/common/slider/DateSlider.tsx
+++ b/src/components/common/slider/DateSlider.tsx
@@ -217,11 +217,26 @@ const DateSliderPoint: React.FC<DateSliderPointProps> = ({
 const SLIDER_MIN_FLOOR = dateToValue(dayjs(dateDefault.min));
 
 /**
- * Parse a date string to slider epoch ms, never below {@link SLIDER_MIN_FLOOR}.
- * Dataset coverage can predate 1970; the control still starts at the floor.
+ * Parse a date string to slider epoch ms at **start of day**, never below
+ * {@link SLIDER_MIN_FLOOR}. Used for the left thumb / rail min.
  */
-const dateStringToSliderValue = (date: string): number =>
+const dateStringToSliderMinValue = (date: string): number =>
   Math.max(SLIDER_MIN_FLOOR, dateToValue(dayjs(date, dateDefault.DATE_FORMAT)));
+
+/**
+ * Parse a date string to slider epoch ms at **end of day**. Used for the right
+ * thumb / rail max so a full-coverage selection reaches the right end of the rail
+ * (start-of-day on maxDate sits left of `max` and collapses onto the left when
+ * min and max share the same calendar day).
+ */
+const dateStringToSliderMaxValue = (date: string): number =>
+  dateToValue(dayjs(date, dateDefault.DATE_FORMAT), true);
+
+/** Full-coverage thumb pair for the current rail bounds. */
+const fullCoverageRange = (minValue: number, maxValue: number): number[] => [
+  minValue,
+  maxValue,
+];
 
 const DateSliderRange: React.FC<DateSliderRangeProps> = ({
   currentMinDate,
@@ -231,18 +246,39 @@ const DateSliderRange: React.FC<DateSliderRangeProps> = ({
   onDateRangeChange,
 }) => {
   // Floor dataset min at 1 Jan 1970 so the rail/thumbs never open earlier.
-  const minValue = useMemo(() => dateStringToSliderValue(minDate), [minDate]);
+  const minValue = useMemo(
+    () => dateStringToSliderMinValue(minDate),
+    [minDate]
+  );
+  // End-of-day so the rail max is after the start-of-day min even on a single day.
   const maxValue = useMemo(
-    () => dateToValue(dayjs(maxDate, dateDefault.DATE_FORMAT)),
+    () => dateStringToSliderMaxValue(maxDate),
     [maxDate]
   );
 
-  const [dateRangeStamp, setDateRangeStamp] = useState<number[]>([
-    dateStringToSliderValue(currentMinDate ? currentMinDate : minDate),
-    dateToValue(
-      dayjs(currentMaxDate ? currentMaxDate : maxDate, dateDefault.DATE_FORMAT)
-    ),
-  ]);
+  /**
+   * Day-sized steps need a track at least one day wide. When min/max are the
+   * same calendar day, max-min ≈ 86400000−1 &lt; DAY_MS and MUI pins both thumbs
+   * to min. Use the full track span as the step so left/right ends are valid.
+   */
+  const stepMs = useMemo(() => {
+    const span = maxValue - minValue;
+    if (span <= 0) return DAY_MS;
+    return span < DAY_MS ? span : DAY_MS;
+  }, [minValue, maxValue]);
+
+  const [dateRangeStamp, setDateRangeStamp] = useState<number[]>(() => {
+    if (currentMinDate || currentMaxDate) {
+      return [
+        dateStringToSliderMinValue(currentMinDate ? currentMinDate : minDate),
+        dateStringToSliderMaxValue(currentMaxDate ? currentMaxDate : maxDate),
+      ];
+    }
+    return fullCoverageRange(
+      dateStringToSliderMinValue(minDate),
+      dateStringToSliderMaxValue(maxDate)
+    );
+  });
 
   const applyRangeValue = useCallback(
     (
@@ -297,9 +333,8 @@ const DateSliderRange: React.FC<DateSliderRangeProps> = ({
       );
       if (Number.isNaN(index) || index < 0 || index > 1) return;
 
-      const step = DAY_MS;
       const current = dateRangeStamp[index];
-      let next = current + direction * step;
+      let next = current + direction * stepMs;
       next = Math.min(maxValue, Math.max(minValue, next));
 
       // Keep thumbs ordered without swapping which one is focused.
@@ -321,23 +356,22 @@ const DateSliderRange: React.FC<DateSliderRangeProps> = ({
       event.stopPropagation();
       applyRangeValue(event, newRange);
     },
-    [applyRangeValue, dateRangeStamp, maxValue, minValue]
+    [applyRangeValue, dateRangeStamp, maxValue, minValue, stepMs]
   );
 
   useEffect(() => {
     startTransition(() => {
-      const newDateRangeStamp = [
-        dateStringToSliderValue(currentMinDate ? currentMinDate : minDate),
-        dateToValue(
-          dayjs(
-            currentMaxDate ? currentMaxDate : maxDate,
-            dateDefault.DATE_FORMAT
-          )
-        ),
-      ];
-      setDateRangeStamp(newDateRangeStamp);
+      if (currentMinDate || currentMaxDate) {
+        setDateRangeStamp([
+          dateStringToSliderMinValue(currentMinDate ? currentMinDate : minDate),
+          dateStringToSliderMaxValue(currentMaxDate ? currentMaxDate : maxDate),
+        ]);
+      } else {
+        // Full coverage: left thumb at start-of-day min, right at end-of-day max
+        setDateRangeStamp(fullCoverageRange(minValue, maxValue));
+      }
     });
-  }, [currentMinDate, currentMaxDate, minDate, maxDate]);
+  }, [currentMinDate, currentMaxDate, minDate, maxDate, minValue, maxValue]);
 
   return (
     <Grid
@@ -382,8 +416,9 @@ const DateSliderRange: React.FC<DateSliderRangeProps> = ({
             value={dateRangeStamp}
             min={minValue}
             max={maxValue}
-            // Values are epoch ms; default step of 1ms makes arrow keys appear broken.
-            step={DAY_MS}
+            // Day steps when the track is ≥1 day; shorter tracks (same calendar
+            // day with endOf max) use the full span so both ends are reachable.
+            step={stepMs}
             shiftStep={MONTH_MS}
             onChangeCommitted={(_, value) => onDateRangeChange(_, value)}
             onChange={handleSliderChange}
@@ -436,7 +471,7 @@ const DateSliderRange: React.FC<DateSliderRangeProps> = ({
             color: portalTheme.palette.text1,
           }}
         >
-          {dayjs(maxDate).format(dateDefault.DISPLAY_FORMAT)}
+          {valueToDate(maxValue).format(dateDefault.DISPLAY_FORMAT)}
         </Typography>
       </Grid>
     </Grid>

--- a/src/components/common/slider/__test__/DateSlider.test.tsx
+++ b/src/components/common/slider/__test__/DateSlider.test.tsx
@@ -88,6 +88,60 @@ describe("DateSliderRange min floor", () => {
     expect(Number(startThumb.getAttribute("aria-valuenow"))).toBe(expected);
     expect(Number(startThumb.getAttribute("aria-valuemin"))).toBe(expected);
   });
+
+  it("places thumbs at rail ends on init (start-of-day min, end-of-day max)", () => {
+    const onDateRangeChange = vi.fn();
+    const minDate = "2020-01-01";
+    const maxDate = "2020-01-31";
+    const minValue = dateToValue(dayjs(minDate, dateDefault.DATE_FORMAT));
+    const maxValue = dateToValue(dayjs(maxDate, dateDefault.DATE_FORMAT), true);
+
+    render(
+      <DateSliderRange
+        currentMinDate={undefined}
+        currentMaxDate={undefined}
+        minDate={minDate}
+        maxDate={maxDate}
+        onDateRangeChange={onDateRangeChange}
+      />
+    );
+
+    const inputs = screen.getAllByRole("slider");
+    expect(Number(inputs[0].getAttribute("aria-valuenow"))).toBe(minValue);
+    expect(Number(inputs[1].getAttribute("aria-valuenow"))).toBe(maxValue);
+    expect(Number(inputs[0].getAttribute("aria-valuemin"))).toBe(minValue);
+    expect(Number(inputs[0].getAttribute("aria-valuemax"))).toBe(maxValue);
+    // Distinct ends — not both stuck on the left
+    expect(Number(inputs[0].getAttribute("aria-valuenow"))).toBeLessThan(
+      Number(inputs[1].getAttribute("aria-valuenow"))
+    );
+  });
+
+  it("places thumbs at both ends when min and max are the same calendar day", () => {
+    // Regression: end thumb used start-of-day while rail max used end-of-day,
+    // so both values equaled min and MUI stacked both dots on the left.
+    const onDateRangeChange = vi.fn();
+    const day = "1970-01-21";
+    const minValue = dateToValue(dayjs(day, dateDefault.DATE_FORMAT));
+    const maxValue = dateToValue(dayjs(day, dateDefault.DATE_FORMAT), true);
+
+    render(
+      <DateSliderRange
+        currentMinDate={undefined}
+        currentMaxDate={undefined}
+        minDate={day}
+        maxDate={day}
+        onDateRangeChange={onDateRangeChange}
+      />
+    );
+
+    const inputs = screen.getAllByRole("slider");
+    expect(Number(inputs[0].getAttribute("aria-valuenow"))).toBe(minValue);
+    expect(Number(inputs[1].getAttribute("aria-valuenow"))).toBe(maxValue);
+    expect(Number(inputs[0].getAttribute("aria-valuemin"))).toBe(minValue);
+    expect(Number(inputs[0].getAttribute("aria-valuemax"))).toBe(maxValue);
+    expect(maxValue).toBeGreaterThan(minValue);
+  });
 });
 
 describe("DateSliderPoint keyboard", () => {

--- a/src/components/map/mapbox/layers/pmtiles/Common.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/Common.tsx
@@ -1,3 +1,5 @@
+import { ExpressionSpecification } from "mapbox-gl";
+
 /** One Mapbox fill band over a PMTiles `hex_z*` source-layer. */
 export type PmtilesHexLayerDef = {
   id: string;
@@ -45,6 +47,12 @@ export const FEATURE_STATE_CHUNK_SIZE = 600;
  * the whole scale rescales (see `DENSITY_COLOR_STOPS` / `DENSITY_OPACITY_STOPS`).
  */
 export const DENSITY_TOTAL_CAP = 10000;
+
+export type HexFillPaint = {
+  "fill-color": ExpressionSpecification | string;
+  "fill-opacity": ExpressionSpecification | number;
+  "fill-outline-color": ExpressionSpecification | string;
+};
 /** Parse sidecar metadata; only `"date"` and `"month"` are accepted. */
 const parseTimeGroupBy = (value: unknown): TimeGroupBy =>
   value === TimeGroupBy.Month

--- a/src/components/map/mapbox/layers/pmtiles/Common.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/Common.tsx
@@ -1,0 +1,74 @@
+/** One Mapbox fill band over a PMTiles `hex_z*` source-layer. */
+export type PmtilesHexLayerDef = {
+  id: string;
+  sourceLayer: string;
+  minzoom: number;
+  maxzoom: number;
+};
+
+/**
+ * Inclusive calendar period as an integer: `YYYYMMDD` (date buckets) or
+ * `YYYYMM` (month buckets). Prefer this over Dayjs for all PMTiles internals.
+ *
+ * Never treat these as unix timestamps — `dayjs(20100815)` is ~1970.
+ */
+export type PeriodInt = number;
+/** Matches sidecar `{dname}.metadata` `time_group_by` from batch PMTiles gen. */
+export enum TimeGroupBy {
+  Date = "date",
+  Month = "month",
+}
+/**
+ * Period coverage from `{dname}.metadata` as integers (same shape as sidecar
+ * `min_date` / `max_date` after validation).
+ */
+export interface PMTilesMetadataRange {
+  minPeriod: PeriodInt;
+  maxPeriod: PeriodInt;
+}
+
+/** Default when `.metadata` is missing or invalid. */
+export const DEFAULT_TIME_GROUP_BY = TimeGroupBy.Date;
+/**
+ * Build a key allow-set when the filter window has at most this many buckets.
+ * Wider day ranges use integer period compares only (building 10k+ keys is wasteful).
+ */
+export const COUNT_KEY_SET_MAX = 2000;
+/** Features to sum + setFeatureState per idle slice (keeps the main thread responsive). */
+export const FEATURE_STATE_CHUNK_SIZE = 400;
+/**
+ * Top density total used by paint interpolate and by the feature-state early-stop.
+ * Totals at or above this value all paint the same; full accuracy is only needed
+ * for the hover popup (which does not use this cap).
+ *
+ * Color/opacity breakpoints are ratios of this value — change only the cap and
+ * the whole scale rescales (see `DENSITY_COLOR_STOPS` / `DENSITY_OPACITY_STOPS`).
+ */
+export const DENSITY_TOTAL_CAP = 10000;
+/** Parse sidecar metadata; only `"date"` and `"month"` are accepted. */
+const parseTimeGroupBy = (value: unknown): TimeGroupBy =>
+  value === TimeGroupBy.Month
+    ? TimeGroupBy.Month
+    : value === TimeGroupBy.Date
+      ? TimeGroupBy.Date
+      : DEFAULT_TIME_GROUP_BY;
+
+/** Digits from a sidecar period number or numeric string (no dayjs). */
+const coercePeriodDigits = (value: unknown): string | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value));
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value.trim());
+    if (Number.isFinite(n)) return String(Math.trunc(n));
+  }
+  return undefined;
+};
+
+/** Absolute count at a density ratio (rounded; keeps 0 exact). */
+const densityStopValue = (
+  ratio: number,
+  cap: number = DENSITY_TOTAL_CAP
+): number => (ratio === 0 ? 0 : Math.max(1, Math.round(ratio * cap)));
+
+export { coercePeriodDigits, parseTimeGroupBy, densityStopValue };

--- a/src/components/map/mapbox/layers/pmtiles/Common.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/Common.tsx
@@ -35,7 +35,7 @@ export const DEFAULT_TIME_GROUP_BY = TimeGroupBy.Date;
  */
 export const COUNT_KEY_SET_MAX = 2000;
 /** Features to sum + setFeatureState per idle slice (keeps the main thread responsive). */
-export const FEATURE_STATE_CHUNK_SIZE = 400;
+export const FEATURE_STATE_CHUNK_SIZE = 600;
 /**
  * Top density total used by paint interpolate and by the feature-state early-stop.
  * Totals at or above this value all paint the same; full accuracy is only needed

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -1534,24 +1534,35 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
   }, [collection]);
 
   // The PMTiles visualization only exists for parquet datasets, so in a mixed
-  // zarr/parquet collection, a non-parquet key falls back to the first parquet key
+  // zarr/parquet collection, a non-parquet key falls back to the first parquet key.
+  // Empty / unset selection must not become `.../undefined.pmtiles` or `.../.pmtiles`.
   const resolveParquetKey = useCallback((): string | undefined => {
-    let key = selectedCoKey;
+    let key =
+      typeof selectedCoKey === "string" && selectedCoKey.trim() !== ""
+        ? selectedCoKey.trim()
+        : undefined;
     if (key && collection?.getDatasetTypeByKey(key) !== DatasetType.PARQUET) {
-      key = collection?.getAllParquetKeys()[0] ?? key;
+      key = collection?.getAllParquetKeys()[0];
     }
-    return key;
+    if (!key) {
+      key = collection?.getAllParquetKeys()[0];
+    }
+    return key || undefined;
   }, [collection, selectedCoKey]);
 
-  const formSourceUrl = useCallback(() => {
+  const formSourceUrl = useCallback((): string | undefined => {
     const key = resolveParquetKey();
-    return `https://${bucket}.s3.${region}.amazonaws.com/portal/visualization/${collection?.id}/${key}.pmtiles`;
+    const collectionId = collection?.id;
+    if (!key || !collectionId) return undefined;
+    return `https://${bucket}.s3.${region}.amazonaws.com/portal/visualization/${collectionId}/${key}.pmtiles`;
   }, [collection?.id, resolveParquetKey]);
 
   // Sidecar written next to the archive by batch PMTiles generation
-  const formMetadataUrl = useCallback(() => {
+  const formMetadataUrl = useCallback((): string | undefined => {
     const key = resolveParquetKey();
-    return `https://${bucket}.s3.${region}.amazonaws.com/portal/visualization/${collection?.id}/${key}.metadata`;
+    const collectionId = collection?.id;
+    if (!key || !collectionId) return undefined;
+    return `https://${bucket}.s3.${region}.amazonaws.com/portal/visualization/${collectionId}/${key}.metadata`;
   }, [collection?.id, resolveParquetKey]);
 
   useEffect(() => {
@@ -1581,7 +1592,7 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
     const metadataUrl = formMetadataUrl();
     const abortController = new AbortController();
 
-    // Reset while the new sidecar loads
+    // Reset while the new sidecar loads (or when dataset key is not ready)
     timeGroupByRef.current = DEFAULT_TIME_GROUP_BY;
     periodBoundsRef.current = null;
     startTransition(() => {
@@ -1589,6 +1600,13 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
       setPeriodBoundsVersion((v) => v + 1);
     });
     onMetadataPeriodChange?.(null);
+
+    // No parquet dataset name yet — do not fetch `.../.metadata` / `.../undefined.metadata`
+    if (!metadataUrl) {
+      return () => {
+        abortController.abort();
+      };
+    }
 
     fetch(metadataUrl, { signal: abortController.signal })
       .then((response) => {
@@ -1657,6 +1675,8 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
     if (!map) return;
 
     const sourceUrl = formSourceUrl();
+    // Dataset name (or collection id) not ready — never add `.../.pmtiles`
+    if (!sourceUrl) return;
 
     const addSourceAndLayers = () => {
       try {

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -58,7 +58,16 @@ const region = import.meta.env.VITE_AWS_REGION;
 // Day cap is high enough for multi-decade daily PMTiles (~55 years).
 const MONTH_KEY_LIMIT = 1200;
 const DAY_KEY_LIMIT = 20000;
-const DEFAULT_RANGE_START = "2000-01-01";
+/**
+ * Fallback UI window start when the user has not set a date filter **and**
+ * `.metadata` bounds are not yet available.
+ *
+ * Must predate any realistic dataset min (was `"2000-01-01"`, which zeroed
+ * all density for pre-2000 tiles such as single-day `19700121` coverage once
+ * clamped against metadata). Prefer using metadata bounds when present —
+ * see {@link buildCountFilterRange}.
+ */
+const DEFAULT_RANGE_START = "1900-01-01";
 /**
  * Trailing debounce so rapid tile `sourcedata` / `idle` events collapse into
  * one feature-state pass after the viewport settles (avoids partial updates).
@@ -304,6 +313,10 @@ export const clampPeriodsToMetadata = (
  * Intersect the UI filter window with metadata period coverage.
  * Converts Dayjs → period ints, clamps with integers, converts back for callers
  * that still expand key lists via dayjs walkers.
+ *
+ * When the UI has not set a filter (`start`/`end` both undefined) and metadata
+ * bounds exist, use the full tile coverage — do not invent a default calendar
+ * window that can miss pre-2000 data.
  */
 export const clampRangeToMetadata = (
   start?: Dayjs,
@@ -311,6 +324,12 @@ export const clampRangeToMetadata = (
   bounds?: PMTilesMetadataRange | null,
   timeGroupBy: TimeGroupBy = DEFAULT_TIME_GROUP_BY
 ): { start: Dayjs; end: Dayjs } => {
+  if (start === undefined && end === undefined && bounds) {
+    const minD = periodNumberToDayjs(bounds.minPeriod, timeGroupBy, "start");
+    const maxD = periodNumberToDayjs(bounds.maxPeriod, timeGroupBy, "end");
+    if (minD && maxD) return { start: minD, end: maxD };
+  }
+
   const { start: s0, end: e0 } = resolveRange(start, end);
   const isDate = timeGroupBy === TimeGroupBy.Date;
   const startPeriod = isDate
@@ -533,6 +552,11 @@ export const buildCountFilterRangeFromPeriods = (
  * Build a reusable filter range for density/popup sums.
  * Converts the UI Dayjs window to {@link PeriodInt} once, then clamps/sums
  * with integers. Optionally attaches a key allow-set when the window is narrow.
+ *
+ * Full-coverage path: when the user has not applied a date filter (both ends
+ * undefined) and `.metadata` bounds are known, sum the entire tile period —
+ * including single-day archives such as min=max=`19700121`. A default window
+ * starting in 2000 would clamp to empty against that coverage.
  */
 export const buildCountFilterRange = (
   filterStart?: Dayjs,
@@ -543,6 +567,15 @@ export const buildCountFilterRange = (
     bounds?: PMTilesMetadataRange | null;
   }
 ): CountFilterRange => {
+  if (filterStart === undefined && filterEnd === undefined && options?.bounds) {
+    return buildCountFilterRangeFromPeriods(
+      options.bounds.minPeriod,
+      options.bounds.maxPeriod,
+      timeGroupBy,
+      options
+    );
+  }
+
   const { start, end } = resolveRange(filterStart, filterEnd);
   const rangeStart = start.startOf("day");
   const rangeEnd = end.startOf("day");

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -29,6 +29,7 @@ import {
   PmtilesHexLayerDef,
   PMTilesMetadataRange,
   PeriodInt,
+  HexFillPaint,
   parseTimeGroupBy,
   TimeGroupBy,
   densityStopValue,
@@ -41,6 +42,7 @@ import { InnerHtmlBuilder } from "@/utils/HtmlUtils";
 import { SelectItem } from "@/components/common/dropdown/CommonSelect";
 import { MapDefaultConfig } from "@/components/map/mapbox/constants";
 import MapLayerSelect from "@/components/map/mapbox/component/MapLayerSelect";
+import { dayjsToDayPeriod, dayjsToMonthPeriod } from "@/utils/DateUtils";
 
 const SOURCE_ID = "pmtiles-source-id";
 const HOVER_SOURCE_ID = "pmtiles-hover-source-id";
@@ -458,14 +460,6 @@ export type CountFilterRange = {
   keySet?: ReadonlySet<string>;
 };
 
-/** Calendar day → YYYYMMDD integer (local calendar fields from dayjs). */
-export const dayjsToDayPeriod = (d: Dayjs): number =>
-  d.year() * 10000 + (d.month() + 1) * 100 + d.date();
-
-/** Calendar month → YYYYMM integer. */
-export const dayjsToMonthPeriod = (d: Dayjs): number =>
-  d.year() * 100 + (d.month() + 1);
-
 /**
  * Parse an mYYYYMM / mYYYYMMDD property name without dayjs.
  * Returns null when the key is not a count bucket.
@@ -877,19 +871,9 @@ export const buildFeatureStateHasCountExpression =
 export const buildDensityLayerFilter = (): ExpressionSpecification =>
   ["has", PROMOTE_ID_PROPERTY] as ExpressionSpecification;
 
-/** @deprecated Use buildDensityLayerFilter — feature-state cannot be used in filters. */
-export const buildFeatureStateNonZeroFilter = (): ExpressionSpecification =>
-  buildDensityLayerFilter();
-
 /** Phase A: any hex feature is present (tiles only contain cells with data). */
 export const buildPresenceFilter = (): ExpressionSpecification =>
   ["has", PROMOTE_ID_PROPERTY] as ExpressionSpecification;
-
-export type HexFillPaint = {
-  "fill-color": ExpressionSpecification | string;
-  "fill-opacity": ExpressionSpecification | number;
-  "fill-outline-color": ExpressionSpecification | string;
-};
 
 export const PLACEHOLDER_FILL_COLOR = "#475569";
 export const PLACEHOLDER_FILL_OPACITY = 0.4;

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -805,13 +805,6 @@ export const buildPopupHtml = (
     .getHtml();
 };
 
-/** @deprecated Prefer feature-state totals; kept for unit tests / tooling. */
-export const buildSumExpression = (keys: string[]) => {
-  if (keys.length === 0) return 0;
-  if (keys.length === 1) return ["coalesce", ["get", keys[0]], 0];
-  return ["+", ...keys.map((k) => ["coalesce", ["get", k], 0])];
-};
-
 /** Density input: sparse total written via setFeatureState (0 when unset). */
 export const buildFeatureStateTotalExpression = (): ExpressionSpecification =>
   [

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -826,6 +826,15 @@ export const buildFeatureStateTotalIsSetExpression =
     ] as ExpressionSpecification;
 
 /**
+ * True when the sparse total is strictly greater than zero.
+ * Used so zero-count hexes (common after a narrow time-slider window) paint
+ * fully transparent — including outline — rather than leaving a faint border.
+ */
+export const buildFeatureStateHasCountExpression =
+  (): ExpressionSpecification =>
+    [">", buildFeatureStateTotalExpression(), 0] as ExpressionSpecification;
+
+/**
  * Layer filter for density mode.
  *
  * IMPORTANT: Mapbox/MapLibre do **not** allow `feature-state` in filters — only
@@ -846,17 +855,22 @@ export const buildPresenceFilter = (): ExpressionSpecification =>
 export type HexFillPaint = {
   "fill-color": ExpressionSpecification | string;
   "fill-opacity": ExpressionSpecification | number;
-  "fill-outline-color": string;
+  "fill-outline-color": ExpressionSpecification | string;
 };
 
 export const PLACEHOLDER_FILL_COLOR = "#475569";
 export const PLACEHOLDER_FILL_OPACITY = 0.4;
+export const PLACEHOLDER_OUTLINE_COLOR = "rgba(255, 255, 255, 0.4)";
+/** Fully transparent fill/outline when a hex has no records in the filter window. */
+export const ZERO_COUNT_FILL_COLOR = "rgba(0, 0, 0, 0)";
+export const ZERO_COUNT_OUTLINE_COLOR = "rgba(0, 0, 0, 0)";
+export const ZERO_COUNT_FILL_OPACITY = 0;
 
 /** Neutral style while feature-state totals are computed in the background. */
 export const getPlaceholderPaintProperties = (): HexFillPaint => ({
   "fill-color": PLACEHOLDER_FILL_COLOR,
   "fill-opacity": PLACEHOLDER_FILL_OPACITY,
-  "fill-outline-color": "rgba(255, 255, 255, 0.4)",
+  "fill-outline-color": PLACEHOLDER_OUTLINE_COLOR,
 });
 
 /**
@@ -864,7 +878,8 @@ export const getPlaceholderPaintProperties = (): HexFillPaint => ({
  *
  * Unset feature-state (tile not yet processed) keeps the placeholder look so
  * newly loaded hexes do not disappear until their sparse total is written.
- * A real total of 0 paints transparent (out of filter range).
+ * A real total of 0 paints fully transparent fill **and** outline (hexes with
+ * no records in the time-slider window must not appear as empty polygons).
  *
  * Color and opacity breakpoints scale with {@link DENSITY_TOTAL_CAP} via
  * {@link DENSITY_COLOR_STOPS} / {@link DENSITY_OPACITY_STOPS}.
@@ -873,6 +888,7 @@ export const getFeatureStatePaintProperties = (
   cap: number = DENSITY_TOTAL_CAP
 ): HexFillPaint => {
   const totalIsSet = buildFeatureStateTotalIsSetExpression();
+  const hasCount = buildFeatureStateHasCountExpression();
   const sumExpr = buildFeatureStateTotalExpression();
   const colorStops = buildDensityInterpolateStops(
     DENSITY_COLOR_STOPS.map(({ ratio, color }) => ({ ratio, value: color })),
@@ -890,15 +906,28 @@ export const getFeatureStatePaintProperties = (
       "case",
       ["!", totalIsSet],
       PLACEHOLDER_FILL_COLOR,
+      ["!", hasCount],
+      ZERO_COUNT_FILL_COLOR,
       ["interpolate", ["linear"], sumExpr, ...colorStops],
     ] as ExpressionSpecification,
     "fill-opacity": [
       "case",
       ["!", totalIsSet],
       PLACEHOLDER_FILL_OPACITY,
+      ["!", hasCount],
+      ZERO_COUNT_FILL_OPACITY,
       ["interpolate", ["linear"], sumExpr, ...opacityStops],
     ] as ExpressionSpecification,
-    "fill-outline-color": "rgba(255, 255, 255, 0.4)",
+    // Data-driven outline: a constant white border still showed on zero-count
+    // hexes. Fully transparent when total is 0 after the time filter.
+    "fill-outline-color": [
+      "case",
+      ["!", totalIsSet],
+      PLACEHOLDER_OUTLINE_COLOR,
+      ["!", hasCount],
+      ZERO_COUNT_OUTLINE_COLOR,
+      PLACEHOLDER_OUTLINE_COLOR,
+    ] as ExpressionSpecification,
   };
 };
 
@@ -1814,6 +1843,23 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
 
       const feature = e.features?.[0];
       if (!feature) return;
+
+      // Authoritative count for the active filter window (same path as popup HTML).
+      // Zero after a narrow time slider → no popup, no hover border, no pointer.
+      const { total: hoverTotal } = sumSparseCountFromProperties(
+        (feature.properties ?? {}) as Record<string, unknown>,
+        filterStartDateRef.current,
+        filterEndDateRef.current,
+        timeGroupByRef.current,
+        {
+          range: countFilterRangeRef.current,
+          collectMatchedKeys: false,
+        }
+      );
+      if (hoverTotal <= 0) {
+        clearHover();
+        return;
+      }
 
       map.getCanvas().classList.add(CURSOR_POINTER_CLASS);
 

--- a/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/PMTilesLayer.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import MapContext from "../MapContext";
+
 import dayjs, { Dayjs } from "dayjs";
 import {
   ExpressionSpecification,
@@ -19,35 +19,60 @@ import {
   Popup,
 } from "mapbox-gl";
 import { FeatureCollection, Geometry } from "geojson";
-import { LayerBasicType } from "./Layers";
-import MapLayerSelect from "../component/MapLayerSelect";
-import { SelectItem } from "../../../common/dropdown/CommonSelect";
-import { InnerHtmlBuilder } from "@/utils/HtmlUtils";
-import { MapDefaultConfig } from "../constants";
-import { playwrightTestIds } from "../../../common/constants";
+
+import {
+  COUNT_KEY_SET_MAX,
+  DEFAULT_TIME_GROUP_BY,
+  FEATURE_STATE_CHUNK_SIZE,
+  DENSITY_TOTAL_CAP,
+  coercePeriodDigits,
+  PmtilesHexLayerDef,
+  PMTilesMetadataRange,
+  PeriodInt,
+  parseTimeGroupBy,
+  TimeGroupBy,
+  densityStopValue,
+} from "./Common";
+import MapContext from "@/components/map/mapbox/MapContext";
 import { DatasetType } from "@/app/store/OGCCollectionDefinitions";
+import { playwrightTestIds } from "@/components/common/constants";
+import { LayerBasicType } from "@/components/map/mapbox/layers/Layers";
+import { InnerHtmlBuilder } from "@/utils/HtmlUtils";
+import { SelectItem } from "@/components/common/dropdown/CommonSelect";
+import { MapDefaultConfig } from "@/components/map/mapbox/constants";
+import MapLayerSelect from "@/components/map/mapbox/component/MapLayerSelect";
 
 const SOURCE_ID = "pmtiles-source-id";
 const HOVER_SOURCE_ID = "pmtiles-hover-source-id";
 const HOVER_OUTLINE_LAYER_ID = "pmtiles-hex-hover-outline";
 const CURSOR_POINTER_CLASS = "map-cursor-pointer";
-/** Feature-state key written by sparse JS sums for density paint/filter. */
-export const FEATURE_STATE_TOTAL = "total";
+/** H3 cell id property; promoted to feature id so feature-state can target hexes. */
+const PROMOTE_ID_PROPERTY = "h";
+const EMPTY_FEATURE_COLLECTION: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+const bucket = import.meta.env.VITE_PMTILES_BUCKET;
+const region = import.meta.env.VITE_AWS_REGION;
+// Caps keep legacy key-list helpers bounded (tests / optional tooling).
+// Day cap is high enough for multi-decade daily PMTiles (~55 years).
+const MONTH_KEY_LIMIT = 1200;
+const DAY_KEY_LIMIT = 20000;
+const DEFAULT_RANGE_START = "2000-01-01";
 /**
- * Top density total used by paint interpolate and by the feature-state early-stop.
- * Totals at or above this value all paint the same; full accuracy is only needed
- * for the hover popup (which does not use this cap).
- *
- * Color/opacity breakpoints are ratios of this value — change only the cap and
- * the whole scale rescales (see `DENSITY_COLOR_STOPS` / `DENSITY_OPACITY_STOPS`).
+ * Trailing debounce so rapid tile `sourcedata` / `idle` events collapse into
+ * one feature-state pass after the viewport settles (avoids partial updates).
  */
-export const DENSITY_TOTAL_CAP = 10000;
+const FEATURE_STATE_DEBOUNCE_MS = 120;
+
+/** Feature-state key written by sparse JS sums for density paint/filter. */
+const FEATURE_STATE_TOTAL = "total";
 
 /**
  * Density fill-color stops as a fraction of {@link DENSITY_TOTAL_CAP}.
  * Ratios must be strictly increasing from 0 to 1.
  */
-export const DENSITY_COLOR_STOPS: ReadonlyArray<{
+const DENSITY_COLOR_STOPS: ReadonlyArray<{
   ratio: number;
   color: string;
 }> = [
@@ -64,7 +89,7 @@ export const DENSITY_COLOR_STOPS: ReadonlyArray<{
  * Density fill-opacity stops as a fraction of {@link DENSITY_TOTAL_CAP}.
  * Ratios must be strictly increasing from 0 toward 1 (need not reach 1).
  */
-export const DENSITY_OPACITY_STOPS: ReadonlyArray<{
+const DENSITY_OPACITY_STOPS: ReadonlyArray<{
   ratio: number;
   opacity: number;
 }> = [
@@ -73,13 +98,6 @@ export const DENSITY_OPACITY_STOPS: ReadonlyArray<{
   { ratio: 0.01, opacity: 0.6 }, // 100
   { ratio: 0.1, opacity: 0.8 }, // 1000
 ];
-
-/** Absolute count at a density ratio (rounded; keeps 0 exact). */
-export const densityStopValue = (
-  ratio: number,
-  cap: number = DENSITY_TOTAL_CAP
-): number => (ratio === 0 ? 0 : Math.max(1, Math.round(ratio * cap)));
-
 /**
  * Flatten ratio-based stops into Mapbox `interpolate` input/output pairs,
  * dropping any non-increasing values after rounding so the expression stays valid.
@@ -99,49 +117,11 @@ export const buildDensityInterpolateStops = <T extends string | number>(
   }
   return pairs;
 };
-/** H3 cell id property; promoted to feature id so feature-state can target hexes. */
-const PROMOTE_ID_PROPERTY = "h";
-const EMPTY_FEATURE_COLLECTION: FeatureCollection = {
-  type: "FeatureCollection",
-  features: [],
-};
-const bucket = import.meta.env.VITE_PMTILES_BUCKET;
-const region = import.meta.env.VITE_AWS_REGION;
-// Caps keep legacy key-list helpers bounded (tests / optional tooling).
-// Day cap is high enough for multi-decade daily PMTiles (~55 years).
-const MONTH_KEY_LIMIT = 1200;
-const DAY_KEY_LIMIT = 20000;
-const DEFAULT_RANGE_START = "2000-01-01";
-/**
- * Build a key allow-set when the filter window has at most this many buckets.
- * Wider day ranges use integer period compares only (building 10k+ keys is wasteful).
- */
-export const COUNT_KEY_SET_MAX = 2000;
-/** Features to sum + setFeatureState per idle slice (keeps the main thread responsive). */
-export const FEATURE_STATE_CHUNK_SIZE = 400;
-
-/** Matches sidecar `{dname}.metadata` `time_group_by` from batch PMTiles gen. */
-export enum TimeGroupBy {
-  Date = "date",
-  Month = "month",
-}
-
-/** Default when `.metadata` is missing or invalid. */
-export const DEFAULT_TIME_GROUP_BY = TimeGroupBy.Date;
-
-/** One Mapbox fill band over a PMTiles `hex_z*` source-layer. */
-export type PmtilesHexLayerDef = {
-  id: string;
-  sourceLayer: string;
-  minzoom: number;
-  maxzoom: number;
-};
-
 /**
  * Zoom bands for hex density fills. Mapbox ranges are half-open:
  * layer is active when `minzoom ≤ zoom < maxzoom` (same as hover gating).
  */
-export const PMTILE_LAYERS: readonly PmtilesHexLayerDef[] = [
+const PMTILE_LAYERS: readonly PmtilesHexLayerDef[] = [
   { id: "pmtiles-hex-z0", sourceLayer: "hex_z0", minzoom: 0, maxzoom: 2 },
   { id: "pmtiles-hex-z2", sourceLayer: "hex_z2", minzoom: 2, maxzoom: 4 },
   { id: "pmtiles-hex-z4", sourceLayer: "hex_z4", minzoom: 4, maxzoom: 6 },
@@ -193,24 +173,6 @@ export const clearInactivePmtilesFeatureState = (
     }
   }
 };
-
-/**
- * Inclusive calendar period as an integer: `YYYYMMDD` (date buckets) or
- * `YYYYMM` (month buckets). Prefer this over Dayjs for all PMTiles internals.
- *
- * Never treat these as unix timestamps — `dayjs(20100815)` is ~1970.
- */
-export type PeriodInt = number;
-
-/**
- * Period coverage from `{dname}.metadata` as integers (same shape as sidecar
- * `min_date` / `max_date` after validation).
- */
-export interface PMTilesMetadataRange {
-  minPeriod: PeriodInt;
-  maxPeriod: PeriodInt;
-}
-
 /**
  * Full coverage range from `{dname}.metadata` including grouping mode.
  */
@@ -234,26 +196,6 @@ const resolveRange = (start?: Dayjs, end?: Dayjs) => ({
   start: start || dayjs(DEFAULT_RANGE_START),
   end: end || dayjs(),
 });
-
-/** Parse sidecar metadata; only `"date"` and `"month"` are accepted. */
-export const parseTimeGroupBy = (value: unknown): TimeGroupBy =>
-  value === TimeGroupBy.Month
-    ? TimeGroupBy.Month
-    : value === TimeGroupBy.Date
-      ? TimeGroupBy.Date
-      : DEFAULT_TIME_GROUP_BY;
-
-/** Digits from a sidecar period number or numeric string (no dayjs). */
-export const coercePeriodDigits = (value: unknown): string | undefined => {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(Math.trunc(value));
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const n = Number(value.trim());
-    if (Number.isFinite(n)) return String(Math.trunc(n));
-  }
-  return undefined;
-};
 
 /**
  * Parse a sidecar `min_date` / `max_date` into a validated {@link PeriodInt}.
@@ -1179,7 +1121,7 @@ export const scheduleDeferredWork = (work: () => void): (() => void) => {
     };
   }
 
-  const timeoutId = setTimeout(run, 0);
+  const timeoutId = setTimeout(run, 10);
   return () => {
     cancelled = true;
     clearTimeout(timeoutId);
@@ -1216,12 +1158,6 @@ export const scheduleChunkedWork = (
     cancelSlice?.();
   };
 };
-
-/**
- * Trailing debounce so rapid tile `sourcedata` / `idle` events collapse into
- * one feature-state pass after the viewport settles (avoids partial updates).
- */
-export const FEATURE_STATE_DEBOUNCE_MS = 120;
 
 export const scheduleDebouncedWork = (
   work: () => void,
@@ -2025,3 +1961,11 @@ const PMTilesHexLayer: FC<PMTilesHexLayerProps> = ({
 };
 
 export default PMTilesHexLayer;
+
+export {
+  FEATURE_STATE_TOTAL,
+  DENSITY_TOTAL_CAP,
+  DENSITY_COLOR_STOPS,
+  DENSITY_OPACITY_STOPS,
+  PMTILE_LAYERS,
+};

--- a/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
@@ -106,10 +106,13 @@ describe("PMTilesLayer - getMonthKeysInRange", () => {
     expect(keys).toEqual([]);
   });
 
-  it("defaults to 2000-01 through the current month when no dates given", () => {
+  it("defaults from 1900-01 when no dates given (capped by MONTH_KEY_LIMIT)", () => {
+    // Fallback only when no UI filter and no .metadata bounds (see DEFAULT_RANGE_START).
+    // 1200 months from 1900-01 stops before the current month.
     const keys = getMonthKeysInRange();
-    expect(keys[0]).toBe("m200001");
-    expect(keys[keys.length - 1]).toBe(`m${dayjs().format("YYYYMM")}`);
+    expect(keys[0]).toBe("m190001");
+    expect(keys.length).toBe(1200);
+    expect(keys[keys.length - 1]).toBe("m199912");
   });
 
   it("caps the number of keys at 1200", () => {
@@ -305,6 +308,17 @@ describe("PMTilesLayer - clampPeriodsToMetadata / clampRangeToMetadata", () => {
     );
     expect(start.format("YYYY-MM-DD")).toBe("2020-01-01");
     expect(end.format("YYYY-MM-DD")).toBe("2020-01-31");
+  });
+
+  it("uses full metadata bounds when no UI filter is provided", () => {
+    const { start, end } = clampRangeToMetadata(
+      undefined,
+      undefined,
+      metaRange(19700121, 19700121, TimeGroupBy.Date),
+      TimeGroupBy.Date
+    );
+    expect(start.format("YYYY-MM-DD")).toBe("1970-01-21");
+    expect(end.format("YYYY-MM-DD")).toBe("1970-01-21");
   });
 });
 
@@ -551,6 +565,45 @@ describe("PMTilesLayer - CountFilterRange (integer + key set)", () => {
     expect(range.endPeriod).toBe(20240120);
     expect(isCountKeyInFilterRange("m20240115", range)).toBe(true);
     expect(isCountKeyInFilterRange("m20240109", range)).toBe(false);
+  });
+
+  it("uses full metadata coverage when no UI filter is set (pre-2000 single day)", () => {
+    // Regression: default window started 2000-01-01, so clamping against
+    // min=max=19700121 produced an empty range and no hexbins at all.
+    const bounds = metaRange(19700121, 19700121, TimeGroupBy.Date);
+    const range = buildCountFilterRange(
+      undefined,
+      undefined,
+      TimeGroupBy.Date,
+      {
+        bounds,
+      }
+    );
+    expect(range.empty).toBe(false);
+    expect(range.startPeriod).toBe(19700121);
+    expect(range.endPeriod).toBe(19700121);
+    expect(isCountKeyInFilterRange("m19700121", range)).toBe(true);
+    expect(isCountKeyInFilterRange("m19700122", range)).toBe(false);
+
+    const { total } = sumSparseCountFromProperties(
+      { h: "cell", m19700121: 42, m20000101: 99 },
+      undefined,
+      undefined,
+      TimeGroupBy.Date,
+      { range }
+    );
+    expect(total).toBe(42);
+  });
+
+  it("still empties when an explicit UI filter is entirely after metadata", () => {
+    const bounds = metaRange(19700121, 19700121, TimeGroupBy.Date);
+    const range = buildCountFilterRange(
+      dayjs("2000-01-01"),
+      dayjs("2020-01-01"),
+      TimeGroupBy.Date,
+      { bounds }
+    );
+    expect(range.empty).toBe(true);
   });
 });
 

--- a/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
@@ -8,8 +8,6 @@ import {
   formatDateKey,
   isCountPropertyInRange,
   buildPopupHtml,
-  buildSumExpression,
-  parseTimeGroupBy,
   periodNumberToDayjs,
   parsePeriodInt,
   parsePMTilesMetadata,
@@ -44,15 +42,19 @@ import {
   DENSITY_TOTAL_CAP,
   DENSITY_COLOR_STOPS,
   DENSITY_OPACITY_STOPS,
-  densityStopValue,
   buildDensityInterpolateStops,
-  COUNT_KEY_SET_MAX,
-  FEATURE_STATE_CHUNK_SIZE,
   PLACEHOLDER_FILL_COLOR,
-  DEFAULT_TIME_GROUP_BY,
-  TimeGroupBy,
-  type PMTilesMetadataRange,
+  buildSumExpression,
 } from "../PMTilesLayer";
+import {
+  COUNT_KEY_SET_MAX,
+  DEFAULT_TIME_GROUP_BY,
+  FEATURE_STATE_CHUNK_SIZE,
+  parseTimeGroupBy,
+  densityStopValue,
+  PMTilesMetadataRange,
+  TimeGroupBy,
+} from "../Common";
 
 /** Test helper: parsePeriodInt that throws if parse fails. */
 const requirePeriodInt = (

--- a/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
@@ -18,6 +18,7 @@ import {
   coerceCountValue,
   buildFeatureStateTotalExpression,
   buildFeatureStateTotalIsSetExpression,
+  buildFeatureStateHasCountExpression,
   buildDensityLayerFilter,
   buildPresenceFilter,
   getPlaceholderPaintProperties,
@@ -44,6 +45,9 @@ import {
   DENSITY_OPACITY_STOPS,
   buildDensityInterpolateStops,
   PLACEHOLDER_FILL_COLOR,
+  ZERO_COUNT_FILL_COLOR,
+  ZERO_COUNT_FILL_OPACITY,
+  ZERO_COUNT_OUTLINE_COLOR,
 } from "../PMTilesLayer";
 import {
   COUNT_KEY_SET_MAX,
@@ -931,6 +935,8 @@ describe("PMTilesLayer - sparse sum and feature-state", () => {
     // Density paint must reference feature-state, not a dense + of day keys
     const density = getFeatureStatePaintProperties();
     const colorJson = JSON.stringify(density["fill-color"]);
+    const opacityJson = JSON.stringify(density["fill-opacity"]);
+    const outlineJson = JSON.stringify(density["fill-outline-color"]);
     expect(colorJson).toContain("feature-state");
     expect(colorJson).not.toContain("m2024");
     // Top color stop must match the early-stop cap
@@ -938,12 +944,25 @@ describe("PMTilesLayer - sparse sum and feature-state", () => {
     // Unset feature-state keeps placeholder so mid-load tiles do not vanish
     expect(colorJson).toContain(PLACEHOLDER_FILL_COLOR);
     expect(colorJson).toContain("case");
+    // Zero-count hexes (narrow time slider) must hide fill and outline
+    expect(colorJson).toContain(ZERO_COUNT_FILL_COLOR);
+    expect(opacityJson).toContain(String(ZERO_COUNT_FILL_OPACITY));
+    expect(outlineJson).toContain("feature-state");
+    expect(outlineJson).toContain(ZERO_COUNT_OUTLINE_COLOR);
     // Default cap preserves the historical absolute breakpoints
     expect(colorJson).toContain("#1E293B");
     expect(colorJson).toContain("#14B8A6");
     for (const input of [0, 1, 10, 100, 1000, 5000, DENSITY_TOTAL_CAP]) {
       expect(colorJson).toContain(String(input));
     }
+  });
+
+  it("builds has-count expression for zero-count transparent paint", () => {
+    expect(buildFeatureStateHasCountExpression()).toEqual([
+      ">",
+      ["coalesce", ["feature-state", FEATURE_STATE_TOTAL], 0],
+      0,
+    ]);
   });
 
   it("scales density color breakpoints with the cap", () => {
@@ -1050,6 +1069,53 @@ describe("PMTilesLayer - sparse sum and feature-state", () => {
         id: "cell-hot",
       },
       { [FEATURE_STATE_TOTAL]: DENSITY_TOTAL_CAP }
+    );
+  });
+
+  it("writes total 0 when a hex has no records in the time-slider window", () => {
+    // After narrowing the slider to a few days, cells that only have data
+    // outside that window must store total 0 so density paint can hide them.
+    const setFeatureState = vi.fn();
+    const map = {
+      getSource: (id: string) => (id === "pmtiles-source-id" ? {} : undefined),
+      querySourceFeatures: (_source: string, opts: { sourceLayer: string }) => {
+        if (opts.sourceLayer !== "hex_z0") return [];
+        return [
+          {
+            id: "in-range",
+            properties: { h: "in-range", m20240115: 4 },
+          },
+          {
+            id: "out-of-range",
+            properties: { h: "out-of-range", m20240601: 99 },
+          },
+        ];
+      },
+      setFeatureState,
+    } as unknown as Map;
+
+    const { updated } = updateFeatureStateTotals(
+      map,
+      dayjs("2024-01-14"),
+      dayjs("2024-01-16"),
+      TimeGroupBy.Date
+    );
+    expect(updated).toBe(2);
+    expect(setFeatureState).toHaveBeenCalledWith(
+      {
+        source: "pmtiles-source-id",
+        sourceLayer: "hex_z0",
+        id: "in-range",
+      },
+      { [FEATURE_STATE_TOTAL]: 4 }
+    );
+    expect(setFeatureState).toHaveBeenCalledWith(
+      {
+        source: "pmtiles-source-id",
+        sourceLayer: "hex_z0",
+        id: "out-of-range",
+      },
+      { [FEATURE_STATE_TOTAL]: 0 }
     );
   });
 

--- a/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
@@ -44,7 +44,6 @@ import {
   DENSITY_OPACITY_STOPS,
   buildDensityInterpolateStops,
   PLACEHOLDER_FILL_COLOR,
-  buildSumExpression,
 } from "../PMTilesLayer";
 import {
   COUNT_KEY_SET_MAX,
@@ -548,28 +547,6 @@ describe("PMTilesLayer - CountFilterRange (integer + key set)", () => {
     expect(range.endPeriod).toBe(20240120);
     expect(isCountKeyInFilterRange("m20240115", range)).toBe(true);
     expect(isCountKeyInFilterRange("m20240109", range)).toBe(false);
-  });
-});
-
-describe("PMTilesLayer - buildSumExpression", () => {
-  it("returns 0 for no keys", () => {
-    expect(buildSumExpression([])).toBe(0);
-  });
-
-  it("returns a single coalesce expression for one key", () => {
-    expect(buildSumExpression(["m20240110"])).toEqual([
-      "coalesce",
-      ["get", "m20240110"],
-      0,
-    ]);
-  });
-
-  it("returns a sum of coalesce expressions for multiple keys", () => {
-    expect(buildSumExpression(["m20240120", "m20240221"])).toEqual([
-      "+",
-      ["coalesce", ["get", "m20240120"], 0],
-      ["coalesce", ["get", "m20240221"], 0],
-    ]);
   });
 });
 

--- a/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
+++ b/src/components/map/mapbox/layers/pmtiles/__test__/PMTilesLayer.test.tsx
@@ -32,8 +32,6 @@ import {
   buildCountFilterRangeFromPeriods,
   isCountKeyInFilterRange,
   parseCountPropertyKey,
-  dayjsToDayPeriod,
-  dayjsToMonthPeriod,
   createFeatureStateTotalsSession,
   featureStateSessionKey,
   getActivePmtilesLayers,
@@ -58,6 +56,7 @@ import {
   PMTilesMetadataRange,
   TimeGroupBy,
 } from "../Common";
+import { dayjsToDayPeriod, dayjsToMonthPeriod } from "@/utils/DateUtils";
 
 /** Test helper: parsePeriodInt that throws if parse fails. */
 const requirePeriodInt = (

--- a/src/pages/detail-page/context/detail-page-provider.tsx
+++ b/src/pages/detail-page/context/detail-page-provider.tsx
@@ -24,12 +24,12 @@ import {
 } from "./DownloadDefinitions";
 import "mapbox-gl/dist/mapbox-gl.css";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
-import { AnalyticsEvent } from "../../../analytics/analyticsEvents";
-import { trackCustomEvent } from "../../../analytics/customEventTracker";
+import { AnalyticsEvent } from "@/analytics/analyticsEvents";
+import { trackCustomEvent } from "@/analytics/customEventTracker";
 import {
   LayerName,
   LayerSwitcherLayer,
-} from "../../../components/map/mapbox/controls/menu/MapLayerSwitcher";
+} from "@/components/map/mapbox/controls/menu/MapLayerSwitcher";
 import { CloudOptimizedFeature } from "@/app/store/CloudOptimizedDefinitions";
 
 interface DetailPageProviderProps {
@@ -93,9 +93,11 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
 
   useEffect(() => {
     if (!uuid) return;
+    let cancelled = false;
     dispatch(fetchResultByUuidNoStore(uuid))
       .unwrap()
       .then((collection) => {
+        if (cancelled) return;
         if (!collection) {
           setIsCollectionNotFound(true);
           return;
@@ -112,31 +114,48 @@ export const DetailPageProvider: FC<DetailPageProviderProps> = ({
         });
       })
       .catch((error) => {
+        if (cancelled) return;
         console.log("Error fetching collection by UUID:", error);
         setIsCollectionNotFound(true);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [dispatch, uuid]);
 
   useEffect(() => {
     if (!uuid) return;
+    let cancelled = false;
     dispatch(fetchFeaturesByUuid(uuid))
       .unwrap()
       .then((features) => {
-        setFeatures(features);
+        if (!cancelled) {
+          setFeatures(features);
+        }
       });
+    return () => {
+      cancelled = true;
+    };
   }, [dispatch, uuid]);
 
   useEffect(() => {
     if (!uuid) return;
+    let cancelled = false;
     dispatch(fetchDatasetMetadataByUuid(uuid))
       .unwrap()
       .then((metadata) => {
-        setDatasetMetadata(metadata);
+        if (!cancelled) {
+          setDatasetMetadata(metadata);
+        }
       })
       .catch((error) => {
+        if (cancelled) return;
         console.log("Error fetching dataset metadata by UUID:", error);
         setDatasetMetadata(undefined);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [dispatch, uuid]);
 
   // PMTiles layer is supported when the dataset_metadata endpoint returns at least

--- a/src/pages/detail-page/features/MapPanel.tsx
+++ b/src/pages/detail-page/features/MapPanel.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { Box } from "@mui/material";
-import { padding } from "../../../styles/constants";
+import { padding } from "@/styles/constants";
 import { useDetailPageContext } from "../context/detail-page-context";
 import Controls from "../../../components/map/mapbox/controls/Controls";
 import NavigationControl from "../../../components/map/mapbox/controls/NavigationControl";
@@ -27,7 +27,7 @@ import {
   PolygonCondition,
   SubsettingType,
 } from "../context/DownloadDefinitions";
-import { dateDefault } from "../../../components/common/constants";
+import { dateDefault } from "@/components/common/constants";
 import {
   Feature,
   FeatureCollection,
@@ -51,22 +51,23 @@ import MenuControlGroup from "../../../components/map/mapbox/controls/menu/MenuC
 import GeojsonLayer from "../../../components/map/mapbox/layers/GeojsonLayer";
 import useBreakpoint from "../../../hooks/useBreakpoint";
 import FitToSpatialExtentsLayer from "../../../components/map/mapbox/layers/FitToSpatialExtentsLayer";
-import { MapEventEnum } from "../../../components/map/mapbox/constants";
-import { fitToDefaultExtent } from "../../../utils/MapUtils";
-import { DateSliderPoint } from "../../../components/common/slider/DateSlider";
-import { dateToValue } from "../../../utils/DateUtils";
+import { MapEventEnum } from "@/components/map/mapbox/constants";
+import { fitToDefaultExtent } from "@/utils/MapUtils";
+import { DateSliderPoint } from "@/components/common/slider/DateSlider";
+import { dateToValue } from "@/utils/DateUtils";
 import { GeoserverFieldsResponse } from "@/app/store/GeoserverDefinitions";
 import * as turf from "@turf/turf";
-import { createStaticLayers } from "../../../components/map/mapbox/layers/StaticLayer";
-import PMTilesHexLayer, {
-  PMTilesMetadata,
-  metadataRangeToDayjs,
-} from "../../../components/map/mapbox/layers/PMTilesLayer";
+import { createStaticLayers } from "@/components/map/mapbox/layers/StaticLayer";
+
 import WmsLegend from "./WmsLegend";
 import {
   DatasetType,
   OGCCollection,
 } from "@/app/store/OGCCollectionDefinitions";
+import PMTilesHexLayer, {
+  metadataRangeToDayjs,
+  PMTilesMetadata,
+} from "@/components/map/mapbox/layers/pmtiles/PMTilesLayer";
 
 const mapContainerId = "map-detail-container-id";
 

--- a/src/pages/search-page/SearchPage.tsx
+++ b/src/pages/search-page/SearchPage.tsx
@@ -155,6 +155,10 @@ const SearchPage = () => {
 
   const doMapSearch = useCallback(
     async (needNavigate: boolean = false) => {
+      // Drop any pending history rewrite from a prior map search. A delayed
+      // navigate() with stale params can wipe a newer search (e.g. searchText).
+      debounceHistoryUpdateRef?.current?.cancel();
+
       const componentParam: ParameterState = getComponentState(
         store.getState()
       );
@@ -213,14 +217,21 @@ const SearchPage = () => {
             // cause all search cancel. However, we also need to make sure that the controller is not canceled
             // and replace by a new one due to new search
             if (needNavigate && controller === mapSearchAbortRef.current) {
+              // Prefer latest Redux params so a concurrent text search is not
+              // overwritten by the bbox snapshot captured when this map search began.
+              const latestParam = getComponentState(store.getState());
               debounceHistoryUpdateRef?.current?.cancel();
               debounceHistoryUpdateRef?.current?.(
-                pageDefault.search + "?" + formatToUrlParam(componentParam)
+                pageDefault.search + "?" + formatToUrlParam(latestParam)
               );
             }
 
             setProgress(undefined);
-            mapSearchAbortRef.current = null;
+            // Only clear if we are still the active search; a newer search may
+            // already own the ref.
+            if (controller === mapSearchAbortRef.current) {
+              mapSearchAbortRef.current = null;
+            }
           });
       }
     },
@@ -229,6 +240,8 @@ const SearchPage = () => {
 
   const doListSearch = useCallback(
     (needNavigate: boolean = false) => {
+      // Ensure a new list/map search never loses to a pending URL rewrite.
+      debounceHistoryUpdateRef?.current?.cancel();
       if (listSearchAbortRef.current) {
         listSearchAbortRef.current.abort();
       }
@@ -447,11 +460,18 @@ const SearchPage = () => {
   }, []);
 
   const cancelAllSearch = useCallback(() => {
+    debounceHistoryUpdateRef?.current?.cancel();
     mapSearchAbortRef.current?.abort();
     mapSearchAbortRef.current = null;
     listSearchAbortRef.current?.abort();
     listSearchAbortRef.current = null;
   }, []);
+
+  // Any real URL change (search button, layout, paste, etc.) invalidates a
+  // pending map-driven history rewrite that may still hold older filters.
+  useEffect(() => {
+    debounceHistoryUpdateRef?.current?.cancel();
+  }, [location.search]);
 
   // You will see this trigger twice, this is due to use of strict-mode
   // which is ok.

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -28,7 +28,9 @@ export const convertDateFormat = (dateString: string): string => {
 };
 
 // Utility function to convert a date to a numeric value
-export const dateToValue = (date: Dayjs): number => date.valueOf();
+export const dateToValue = (date: Dayjs, endOfDay: boolean = false): number => {
+  return endOfDay ? date.endOf("day").valueOf() : date.valueOf();
+};
 
 // Utility function to convert a numeric value back to a date
 export const valueToDate = (value: number): Dayjs => dayjs(value);

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -34,3 +34,11 @@ export const dateToValue = (date: Dayjs, endOfDay: boolean = false): number => {
 
 // Utility function to convert a numeric value back to a date
 export const valueToDate = (value: number): Dayjs => dayjs(value);
+
+/** Calendar day → YYYYMMDD integer (local calendar fields from dayjs). */
+export const dayjsToDayPeriod = (d: Dayjs): number =>
+  d.year() * 10000 + (d.month() + 1) * 100 + d.date();
+
+/** Calendar month → YYYYMM integer. */
+export const dayjsToMonthPeriod = (d: Dayjs): number =>
+  d.year() * 100 + (d.month() + 1);


### PR DESCRIPTION
1. Fix issue with time slider where start and end is the same
2. Do not show popup when the hexbin have zero count, do not show the hexbin too
3. Tune constant to make the draw looks faster
4. Refactor to reduce the size of the file